### PR TITLE
chore: avoid compile error on mac

### DIFF
--- a/setup/c_ext.py
+++ b/setup/c_ext.py
@@ -133,6 +133,10 @@ if toolset == "gcc":
         extra_link_args += [
             osx_sdk,
         ]
+        define_macros += [
+            # https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
+            ("_LIBCPP_DISABLE_AVAILABILITY", None),
+        ]
 
     else:
         extra_compile_args += [


### PR DESCRIPTION
see https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk

Release-As: 4.1.2