### PR TITLE
chore: separate build caches

### DIFF
--- a/.github/actions/build-gk/action.yaml
+++ b/.github/actions/build-gk/action.yaml
@@ -14,11 +14,18 @@ runs:
       id: restore_mamba_cache
       uses: actions/cache/restore@v4
       with:
-        key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**', 'conda-recipe/meta.yaml') }}
+        key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**') }}
         path: |
           ~/micromamba
           ~/.condarc
           ~/bin/micromamba
+
+    - name: try to restore the gk package tarballs
+      id: restore_gk_pkg
+      uses: actions/cache/restore@v4
+      with:
+        key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**', 'conda-recipe/meta.yaml', 'src/**', 'genome_kit/**') }}
+        path: |
           ~/conda-bld
 
     - name: install mamba
@@ -62,7 +69,7 @@ runs:
         mkdir -p ~/.ccache
         set +x
 
-    - if: ${{ steps.restore_mamba_cache.outputs.cache-hit != 'true' }}
+    - if: ${{ steps.restore_gk_pkg.outputs.cache-hit != 'true' }}
       name: build conda package
       shell: bash -l -e {0}
       run: |
@@ -77,9 +84,16 @@ runs:
       id: save_mamba_cache
       uses: actions/cache/save@v4
       with:
-        key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**', 'conda-recipe/meta.yaml') }}
+        key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**') }}
         path: |
           ~/micromamba
           ~/.condarc
           ~/bin/micromamba
+
+    - name: cache gk package tarballs
+      id: save_gk_pkg
+      uses: actions/cache/save@v4
+      with:
+        key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**', 'conda-recipe/meta.yaml', 'src/**', 'genome_kit/**') }}
+        path: |
           ~/conda-bld

--- a/.github/actions/curl-meta-yaml/action.yaml
+++ b/.github/actions/curl-meta-yaml/action.yaml
@@ -9,7 +9,6 @@ runs:
         mkdir -p conda-recipe
         curl -s -L -o conda-recipe/meta.yaml https://raw.githubusercontent.com/conda-forge/genomekit-feedstock/main/recipe/meta.yaml
         # build from local source, not from the latest release tarball
-        sed -i -e 's|url: https://github.com/deepgenomics/GenomeKit/archive/refs/tags/v.*$|path: ../|1' \
-          -e '/sha256: /d' conda-recipe/meta.yaml
+        sed -i -e 's|url: https://github.com/deepgenomics/GenomeKit/archive/refs/tags/v.*$|path: ../|1; /sha256: /d' conda-recipe/meta.yaml
         head -10 conda-recipe/meta.yaml
         set +x

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -30,11 +30,19 @@ jobs:
         id: restore_mamba_cache
         uses: actions/cache/restore@v4
         with:
-          key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**', 'conda-recipe/meta.yaml') }}
+          key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**') }}
           path: |
             ~/micromamba
             ~/.condarc
             ~/bin/micromamba
+          fail-on-cache-miss: true
+
+      - name: restore the gk package tarballs
+        id: restore_gk_pkg
+        uses: actions/cache/restore@v4
+        with:
+          key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**', 'conda-recipe/meta.yaml', 'src/**', 'genome_kit/**') }}
+          path: |
             ~/conda-bld
           fail-on-cache-miss: true
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -38,11 +38,19 @@ jobs:
         id: restore_mamba_cache
         uses: actions/cache/restore@v4
         with:
-          key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**', 'conda-recipe/meta.yaml') }}
+          key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**') }}
           path: |
             ~/micromamba
             ~/.condarc
             ~/bin/micromamba
+          fail-on-cache-miss: true
+
+      - name: restore the gk package tarballs
+        id: restore_gk_pkg
+        uses: actions/cache/restore@v4
+        with:
+          key: mamba-env-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('.github/workflows/run-tests.yaml', '.github/actions/**', 'conda-recipe/meta.yaml', 'src/**', 'genome_kit/**') }}
+          path: |
             ~/conda-bld
           fail-on-cache-miss: true
 


### PR DESCRIPTION
separate package tarball cache from mamba build/test envs

also: fix sed invocation on osx