### PR TITLE
fix: provide a better hint in case of permissions error

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -54,6 +54,8 @@ enabled, so you will need to
 - set the ``GENOMEKIT_GCS_BILLING_PROJECT`` env var to your Google Cloud project::
 
     export GENOMEKIT_GCS_BILLING_PROJECT="your-project-id"
+    # required depending on your local gcloud configuration
+    export GOOGLE_CLOUD_PROJECT="your-project-id"
 
 For more details on creating your own data source, see `the section on Sharing data files <sharing data>`_.
 

--- a/genome_kit/data_manager.py
+++ b/genome_kit/data_manager.py
@@ -189,7 +189,7 @@ class DefaultDataManager(DataManager):
                 self._bucket = gcloud_client.bucket(_GCS_BUCKET, user_project=os.environ.get("GENOMEKIT_GCS_BILLING_PROJECT", None))
             except Exception as e:
                 # give the user a hint in case of permission errors
-                print(e)
+                print(e, file=sys.stderr)
                 raise
 
         return self._bucket

--- a/genome_kit/data_manager.py
+++ b/genome_kit/data_manager.py
@@ -4,6 +4,7 @@ import base64
 import hashlib
 import logging
 import os
+import sys
 import tempfile
 from abc import ABC
 from contextlib import contextmanager
@@ -206,7 +207,7 @@ class DefaultDataManager(DataManager):
                 raise FileNotFoundError(f"File '{filename}' not found in the GCS bucket")
         except Exception as e:
             # give the user a hint in case of permission errors
-            print(e)
+            print(e, file=sys.stderr)
             raise
 
         # form a temporary filename to make the download safe


### PR DESCRIPTION
refg.cpp masks any exception raised in python, and the message can be misleading:
> Assembly is missing its chrom.sizes or annotation is missing its cfg file: {}