### PR TITLE
chore: unqualified style warning on newest clang

### DIFF
--- a/src/variant_table.cpp
+++ b/src/variant_table.cpp
@@ -1021,7 +1021,7 @@ void vcf_table::builder::build(const char* outfile)
 }
 
 vcf_table::vcf_table(mmap_file&& mapped)
-	: _fmap(move(mapped))
+	: _fmap(std::move(mapped))
 {
 	auto sig = _fmap.read<unsigned short>();
 	auto ver = _fmap.read<unsigned short>();


### PR DESCRIPTION
fyi there's also some warnings around the signed/unsigned wrapping in dna now