### PR TITLE
fix: avoid user confusion when loading annotation

### DIFF
--- a/docs-src/develop.rst
+++ b/docs-src/develop.rst
@@ -53,7 +53,7 @@ You can also run examples from the ``demos`` directory.
 
 
 Jetbrains CLion setup
---------------
+---------------------
 
 In the CMake settings, set the following environment variables::
 

--- a/docs-src/quickstart.rst
+++ b/docs-src/quickstart.rst
@@ -843,7 +843,7 @@ implementation of :py:class:`genome_kit.data_manager.DataManager` and register i
 
 
 Logging and troubleshooting
-----------------------
+---------------------------
 
 Set the ``GENOMEKIT_QUIET`` to any value to suppress logging output.
 

--- a/docs-src/quickstart.rst
+++ b/docs-src/quickstart.rst
@@ -616,7 +616,7 @@ respect to insertions/deletions. Read on and learn about
 
 
 Variant genomes
-^^^^^^^^^^^^^^^
+---------------
 
 Variant genomes are made by applying a zero or more variants to a reference
 genome via the :py:class:`.VariantGenome` class.
@@ -660,7 +660,7 @@ by 'anchoring' an interval.
 
 
 Length-changing variants
-^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------
 
 Variants that insert or delete positions (INDELs) effectively change the
 coordinate system of the variant genome. If an interval is specified on the

--- a/docs-src/quickstart.rst
+++ b/docs-src/quickstart.rst
@@ -840,3 +840,11 @@ implementation of :py:class:`genome_kit.data_manager.DataManager` and register i
     # endpoint under the "genomekit.plugins.data_manager" group. GenomeKit will automatically
     # use the plugin's data manager.
     # (see https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins)
+
+
+Logging and troubleshooting
+----------------------
+
+Set the ``GENOMEKIT_QUIET`` to any value to suppress logging output.
+
+Set the ``GENOMEKIT_TRACE`` to any value to enable trace logging.

--- a/genome_kit/data_manager.py
+++ b/genome_kit/data_manager.py
@@ -206,9 +206,10 @@ class DefaultDataManager(DataManager):
             if not blob.exists():
                 raise FileNotFoundError(f"File '{filename}' not found in the GCS bucket")
         except Exception as e:
-            # give the user a hint in case of permission errors
-            print(e, file=sys.stderr)
-            raise
+            if "GK_TRACE" in os.environ:
+                # give the user a hint in case of permission errors
+                print(e, file=sys.stderr)
+                raise
 
         # form a temporary filename to make the download safe
         temp_file = tempfile.NamedTemporaryFile(delete=False, mode="wb", dir=self.data_dir, prefix=filename, suffix=".part")

--- a/genome_kit/data_manager.py
+++ b/genome_kit/data_manager.py
@@ -206,7 +206,7 @@ class DefaultDataManager(DataManager):
             if not blob.exists():
                 raise FileNotFoundError(f"File '{filename}' not found in the GCS bucket")
         except Exception as e:
-            if "GK_TRACE" in os.environ:
+            if "GENOMEKIT_TRACE" in os.environ:
                 # give the user a hint in case of permission errors
                 print(e, file=sys.stderr)
                 raise

--- a/genome_kit/genome.py
+++ b/genome_kit/genome.py
@@ -33,7 +33,7 @@ class Genome(_cxx.Genome):
         Genome("gencode.v29")
 
     The currently recognized strings depend on the data made available by data_manager.
-    Some common ones are:
+    Some common ones are::
 
         reference_genomes = [
             "hg19",


### PR DESCRIPTION
Users need to set env var GK_TRACE in order to troubleshoot bucket access issues.

Otherwise users may see a confusing message like this every time: File 'ncbi_refseq.v109.chrom.sizes' not found in the GCS bucket