### PR TITLE
fix: broken installation on osx-arm64

### DIFF
--- a/genomekit_dev.yml
+++ b/genomekit_dev.yml
@@ -5,7 +5,6 @@ channels:
   - bioconda
 dependencies:
   - appdirs>=1.4.0
-  - crc32c
   - fmt
   - numpy
   - python>=3.8.0,<3.11.0


### PR DESCRIPTION
crc32c isn't available for arm64 but isn't used