### PR TITLE
fix(track): segfault when decoding large dims

### DIFF
--- a/src/genome_track_io.cpp
+++ b/src/genome_track_io.cpp
@@ -666,12 +666,12 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 		// Reverse the order so that it's written in reference-strand order.
 		// (The genome_track decoders always assumes blocks of
 		//  contiguous data are stored in reference-strand order.)
-		alt_data = std::make_unique<T[]>(size*dim);
+		alt_data = std::make_unique<T[]>((size_t)size*dim);
 		src = &alt_data[0];
 		if (reverse)
 			reverse_track_data(&alt_data[0], data, size, dim);
 		else
-			memcpy(&alt_data[0], data, size*dim*dtype_size[dtype]);
+			memcpy(&alt_data[0], data, (size_t)size*dim*dtype_size[dtype]);
 
 		// Transform the data if needed
 		if (_data_transform)
@@ -685,7 +685,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 		// This is important for allowing _sparsity_min_delta to attract a larger range of values
 		// than would normally be achieved by merely rounding to nearest encodable value.
 		if (sparsify)
-			for (int i = 0; i < size*dim; ++i)
+			for (size_t i = 0; i < (size_t)size*dim; ++i)
 				if (is_default(alt_data[i]))
 					alt_data[i] = _h.default_value.as<T>();
 	}
@@ -701,7 +701,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 		encoding::decode_fn decode = _encoding.decoders[dtype][as_ordinal(pos_strand)];  // decode forward, regardless of interval strand
 		GK_ASSERT(decode);  // should always be a decoder for dtype if there was an encoder
 		if (!alt_data)
-			alt_data = std::make_unique<T[]>(size*dim);
+			alt_data = std::make_unique<T[]>((size_t)size*dim);
 		decode(&alt_data[0], &dst[0], _encoding.dict.get<T>(), size, dim, 0, 0);  // Fill `alt_data` by decoding `dst`
 
 		// Now that we've decoded the encoded data, thereby quantizing the data as it would
@@ -716,7 +716,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 			// Find the next position where at least ONE element IS NOT default_value
 			while (start < size) {
 				int j = 0;
-				while (j < dim && is_default(alt_data[start*dim+j]))
+				while (j < dim && is_default(alt_data[(size_t)start*dim+j]))
 					++j;
 				if (j < dim)
 					break;
@@ -729,7 +729,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 			int end = start+1;
 			while (end < size) {
 				int j = 0;
-				while (j < dim && is_default(alt_data[end*dim+j]))
+				while (j < dim && is_default(alt_data[(size_t)end*dim+j]))
 					++j;
 
 				// At least one non-default value? If so, keep scanning
@@ -743,7 +743,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 				int next_start = end+1;
 				while (next_start < size) {
 					int k = 0;
-					while (k < dim && is_default(alt_data[next_start*dim+k]))
+					while (k < dim && is_default(alt_data[(size_t)next_start*dim+k]))
 						++k;
 					if (k < dim)
 						break;
@@ -761,7 +761,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 			auto sub_dst = std::make_unique<uint8_t[]>(_encoding.num_encoded_bytes(sub_span.size(), dim));
 
 			// Encode the sub-interval into the smaller dst buffer
-			encode(&sub_dst[0], &alt_data[start*dim], _encoding.dict, sub_span.size(), dim);
+			encode(&sub_dst[0], &alt_data[(size_t)start*dim], _encoding.dict, sub_span.size(), dim);
 
 			// Insert the sub-interval into the data block map, and leave the memory be
 			add_track_entry(adder, sub_span, std::move(sub_dst));

--- a/src/util.h
+++ b/src/util.h
@@ -177,12 +177,14 @@ constexpr bool in_range(T x, V lo, V hi)
 	}
 
 template <typename T> struct int_traits { };
-GK_DEFINE_INT_TRAITS(unsigned char     ,                            0, 255u,                    void,          unsigned short     , unsigned char );
-GK_DEFINE_INT_TRAITS(         char     ,                         -128, 127,                     void,                   short     , unsigned char );
-GK_DEFINE_INT_TRAITS(unsigned short    ,                            0, 65535u,                  unsigned char, unsigned int       , unsigned short);
-GK_DEFINE_INT_TRAITS(         short    ,                       -32768, 32767,                            char,          int       , unsigned short);
+GK_DEFINE_INT_TRAITS(unsigned char     ,                            0, 255u,                    void,           unsigned short    , unsigned char );
+GK_DEFINE_INT_TRAITS(         char     ,                         -128, 127,                     void,                    short    , unsigned char );
+GK_DEFINE_INT_TRAITS(unsigned short    ,                            0, 65535u,                  unsigned char,  unsigned int      , unsigned short);
+GK_DEFINE_INT_TRAITS(         short    ,                       -32768, 32767,                            char,           int      , unsigned short);
 GK_DEFINE_INT_TRAITS(unsigned int      ,                            0, 4294967295u,             unsigned short, unsigned long long, unsigned int  );
 GK_DEFINE_INT_TRAITS(         int      ,                -2147483648ll, 2147483647,                       short,          long long, unsigned int  );
+GK_DEFINE_INT_TRAITS(unsigned long     ,                            0, 18446744073709551615ull, unsigned int,   void              , unsigned long );
+GK_DEFINE_INT_TRAITS(         long     ,       (long)0x800000000000ul, 9223372036854775807l,             int,   void              , unsigned long );
 GK_DEFINE_INT_TRAITS(unsigned long long,                            0, 18446744073709551615ull, unsigned int,   void              , unsigned long long);
 GK_DEFINE_INT_TRAITS(         long long, (long long)0x800000000000ull, 9223372036854775807ll,            int,   void              , unsigned long long);
 
@@ -319,9 +321,9 @@ private:
 
 ////////////////////////////////////////////////////
 
-template <typename T> INLINE T divup(T x, T denom) { return (x+denom-1) / denom;     }
-template <typename T> INLINE T rndup(T x, T align) { return divup(x, align) * align; }
-template <typename T> INLINE T rnddn(T x, T align) { return (x/align) * align;       }
+template <typename T, typename U> INLINE T divup(T x, U denom) { return (x+denom-1) / denom;     }
+template <typename T, typename U> INLINE T rndup(T x, U align) { return divup(x, align) * align; }
+template <typename T, typename U> INLINE T rnddn(T x, U align) { return (x/align) * align;       }
 
 // The udiv* functions are useful for dividing signed integers with
 // unsigned division. Unsigned division is faster when both 'a' and 'b'
@@ -339,20 +341,20 @@ template <typename T> INLINE T rnddn(T x, T align) { return (x/align) * align;  
 //
 // See discussion https://google.github.io/styleguide/cppguide.html#Integer_Types
 //
-template <typename T> INLINE T udivdn(T x, T denom)
+template <typename T, typename V> INLINE T udivdn(T x, V denom)
 {
 	using U = typename int_traits<T>::unsigned_type;
 	return T((U)x / (U)denom);  // Round down
 }
 
-template <typename T> INLINE T udivup(T x, T denom)
+template <typename T, typename V> INLINE T udivup(T x, V denom)
 {
 	using U = typename int_traits<T>::unsigned_type;
 	return T(((U)x+(U)denom-1) / (U)denom);  // Round up
 }
 
 // Unsigned modulus operator (%) applicable to signed types.
-template <typename T> INLINE T umod(T x, T denom)
+template <typename T, typename V> INLINE T umod(T x, V denom)
 {
 	using U = typename int_traits<T>::unsigned_type;
 	return T((U)x % (U)denom);  // Round down


### PR DESCRIPTION
GK uses int32s for interval positions, but when multiplied with a dim component for storing/reading tracks, this can overflow (ie, reading/writing to negative positions).

There are several existing size_t promotions in the encode logic, so the simplest method is to do an onsite promote (rather than rework the logic to handel unsigned comparisons w/ underflow).