### PR TITLE
fix(track): handle res>1 for track interval interrogation

### DIFF
--- a/src/genome_track.cpp
+++ b/src/genome_track.cpp
@@ -561,7 +561,7 @@ std::vector<interval_t> genome_track::intervals() const
 		const auto starts     = rcast<const pos_t*>(ends + num_blocks);
 
 		for (std::decay_t<decltype(num_blocks)> i_block{}; i_block < num_blocks; ++i_block) {
-			ret[i_itv] = interval_t::from_dna0(k.chrom, starts[i_block], ends[i_block], k.other, _refg);
+			ret[i_itv] = interval_t::from_dna0(k.chrom, starts[i_block] * _res, ends[i_block] * _res, k.other, _refg);
 			++i_itv;
 		}
 	}

--- a/src/py_genome_track.cpp
+++ b/src/py_genome_track.cpp
@@ -204,7 +204,7 @@ GKPY_OMETHOD_BEGIN(GenomeTrackBuilder, set_data)
 
 		// Check the data array to make sure it's contiguous, C-order, and 1- or 2-dimensions.
 		GK_CHECK(ndim == 1 || ndim == 2, value, "Data must be 1- or 2-dimensional");
-		GK_CHECK((int)PyArray_DIMS(py_data)[0]*res == interval.size(), value, "Data must have {} rows", interval.size());
+		GK_CHECK((int)PyArray_DIMS(py_data)[0]*res == interval.size(), value, "Data must have {} rows", (int)(interval.size()/res));
 		if (ndim > 1) {
 			GK_CHECK((int)PyArray_DIMS(py_data)[1] == self->builder->dim(), value, "Data must have {} columns", self->builder->dim());
 			GK_CHECK(PyArray_FLAGS(py_data) & NPY_ARRAY_CARRAY_RO, value, "Multi-dimensional data array must be C_CONTIGUOUS order");

--- a/tests/test_genome_track.py
+++ b/tests/test_genome_track.py
@@ -297,6 +297,16 @@ class TestBuildTrack(unittest.TestCase):
         with GenomeTrack(self.tmpfile) as track:
             self.assertEqual(set(intervals), set(track.intervals))
 
+        builder = self.make_builder(strandedness="strand_aware", resolution=5)
+        intervals = [Interval('chr1', '+', 10, 30, builder.refg)]
+        intervals.append(intervals[0].as_opposite_strand().shift(1))
+        builder.set_data(intervals[0], np.zeros((20, 1), np.float16))
+        builder.set_data(intervals[1], np.ones((20, 1), np.float16))
+        builder.finalize()
+
+        with GenomeTrack(self.tmpfile) as track:
+            self.assertEqual(set(intervals), set(track.intervals))
+
     def test_out(self):
         # Build a valid .gtrack file for some tests
         builder = self.make_builder(strandedness="strand_aware")

--- a/tests/test_genome_track.py
+++ b/tests/test_genome_track.py
@@ -299,9 +299,9 @@ class TestBuildTrack(unittest.TestCase):
 
         builder = self.make_builder(strandedness="strand_aware", resolution=5)
         intervals = [Interval('chr1', '+', 10, 30, builder.refg)]
-        intervals.append(intervals[0].as_opposite_strand().shift(1))
-        builder.set_data(intervals[0], np.zeros((4, 1), np.float16))
-        builder.set_data(intervals[1], np.ones((4, 1), np.float16))
+        intervals.append(intervals[0].as_opposite_strand().shift(5))
+        builder.set_data(intervals[0], np.zeros((20//5, 1), np.float16))
+        builder.set_data(intervals[1], np.ones((20//5, 1), np.float16))
         builder.finalize()
 
         with GenomeTrack(self.tmpfile) as track:

--- a/tests/test_genome_track.py
+++ b/tests/test_genome_track.py
@@ -300,8 +300,8 @@ class TestBuildTrack(unittest.TestCase):
         builder = self.make_builder(strandedness="strand_aware", resolution=5)
         intervals = [Interval('chr1', '+', 10, 30, builder.refg)]
         intervals.append(intervals[0].as_opposite_strand().shift(1))
-        builder.set_data(intervals[0], np.zeros((20, 1), np.float16))
-        builder.set_data(intervals[1], np.ones((20, 1), np.float16))
+        builder.set_data(intervals[0], np.zeros((4, 1), np.float16))
+        builder.set_data(intervals[1], np.ones((4, 1), np.float16))
         builder.finalize()
 
         with GenomeTrack(self.tmpfile) as track:


### PR DESCRIPTION
#71 added GenomeTrack.intervals. It incorrectly handles tracks where resolution>1. For resolution n, it only returns intervals corresponding to the first 1/n  of each chromosome.

see https://github.com/deepgenomics/GenomeKit/blob/e2c8dd1e5a6f7482062892b043cb613450b4cd4b/src/genome_track_io.cpp#L576-L582

for how resolutions are encoded.