### PR TITLE
fix(track): sparse encoding broken

### DIFF
--- a/src/genome_track_io.cpp
+++ b/src/genome_track_io.cpp
@@ -702,7 +702,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 		GK_ASSERT(decode);  // should always be a decoder for dtype if there was an encoder
 		if (!alt_data)
 			alt_data = std::make_unique<T[]>((size_t)size*dim);
-		decode(&alt_data[0], &dst[0], _encoding.dict.get<T>(), size, dim, 0, 0, 0);  // Fill `alt_data` by decoding `dst`
+		decode(&alt_data[0], &dst[0], _encoding.dict.get<T>(), size, dim, 0, 0, dim);  // Fill `alt_data` by decoding `dst`
 
 		// Now that we've decoded the encoded data, thereby quantizing the data as it would
 		// appear in the final track, we're ready to scan the decoded copy for blocks of


### PR DESCRIPTION
the stride parameter
(introduced in
https://github.com/deepgenomics/GenomeKit/pull/84) was not passed correctly for the decode function to test value runs.