### PR TITLE
chore: fix ambiguous C decode fn

### DIFF
--- a/src/genome_track.cpp
+++ b/src/genome_track.cpp
@@ -51,7 +51,7 @@ genome_track::dtype_t genome_track::etype_default_dtype[genome_track::num_etype]
 	genome_track::float32,  // f32
 };
 
-const char* genome_track::dtype_as_cstr[genome_track::num_dtype] = {
+const char* genome_track::dtype_as_cstr[as_ordinal(genome_track::num_dtype)] = {
 	"bool",
 	"uint8",
 	"int8",
@@ -59,7 +59,7 @@ const char* genome_track::dtype_as_cstr[genome_track::num_dtype] = {
 	"float32",
 };
 
-int genome_track::dtype_size[genome_track::num_dtype] = {
+int genome_track::dtype_size[as_ordinal(genome_track::num_dtype)] = {
 	sizeof(bool),    // bool_
 	sizeof(uint8_t), // uint8
 	sizeof(int8_t),  // int8
@@ -69,7 +69,7 @@ int genome_track::dtype_size[genome_track::num_dtype] = {
 
 genome_track::dtype_t genome_track::as_dtype(const char* s)
 {
-	for (int i = 0; i < genome_track::num_dtype; ++i)
+	for (int i = 0; i < as_ordinal(genome_track::num_dtype); ++i)
 		if (!strcmp(s, dtype_as_cstr[i]))
 			return (genome_track::dtype_t)i;
 	GK_THROW(value, "Unrecognized dtype '{}'", s);
@@ -77,7 +77,7 @@ genome_track::dtype_t genome_track::as_dtype(const char* s)
 
 genome_track::etype_t genome_track::as_etype(const char* s)
 {
-	for (int i = 0; i < genome_track::num_etype; ++i)
+	for (int i = 0; i < as_ordinal(genome_track::num_etype); ++i)
 		if (!strcmp(s, etype_as_cstr[i]))
 			return (genome_track::etype_t)i;
 	GK_THROW(value, "Unrecognized etype '{}'", s);
@@ -127,9 +127,9 @@ void genome_track::operator()(const interval_t& c, void*    dst, dtype_t dtype, 
 	const int layout = as_ordinal(stride == dim() ? encoding::layout_t::contiguous : encoding::layout_t::noncontiguous);
 
 	// Get callbacks that are specialized to decode and default fill for this dtype and strand direction.
-	encoding::decode_fn decode = _encoding.decoders[dtype][layout][as_ordinal(c.strand)];
-	encoding::dfill_fn  dfill  = _encoding.dfillers[dtype][layout][as_ordinal(c.strand)];
-	GK_CHECK(decode, type, "Cannot decode as {} from encoded type {}", dtype_as_cstr[dtype], etype_as_cstr[_encoding.etype]);
+	encoding::decode_fn decode = _encoding.decoders[as_ordinal(dtype)][layout][as_ordinal(c.strand)];
+	encoding::dfill_fn  dfill  = _encoding.dfillers[as_ordinal(dtype)][layout][as_ordinal(c.strand)];
+	GK_CHECK(decode, type, "Cannot decode as {} from encoded type {}", dtype_as_cstr[as_ordinal(dtype)], etype_as_cstr[_encoding.etype]);
 	GK_DBASSERT(dfill);
 
 	static constexpr track_index_t null_index{};
@@ -533,7 +533,7 @@ done:
 			if (phase == _res)
 				phase = 0;
 		}
-		_encoding.expanders[dtype][layout](dst, c.size(), dim, ce-cs, _res, phase, stride);
+		_encoding.expanders[as_ordinal(dtype)][layout](dst, c.size(), dim, ce-cs, _res, phase, stride);
 	}
 }
 

--- a/src/genome_track_io.cpp
+++ b/src/genome_track_io.cpp
@@ -651,8 +651,8 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 	dtype_t dtype = dtype_traits<T>::dtype;
 	int dim = _h.dim;
 	auto dst = std::make_unique<uint8_t[]>(_encoding.num_encoded_bytes(size, dim));
-	encoding::encode_fn encode = _encoding.encoders[dtype];
-	GK_CHECK(encode, type, "Cannot encode as {} using decoded type {}", etype_as_cstr[_encoding.etype], dtype_as_cstr[dtype]);
+	encoding::encode_fn encode = _encoding.encoders[as_ordinal(dtype)];
+	GK_CHECK(encode, type, "Cannot encode as {} using decoded type {}", etype_as_cstr[_encoding.etype], dtype_as_cstr[as_ordinal(dtype)]);
 
 	// The source pointer we'll 'encode' from, which may be original data or
 	// may be redirected to transformed data.
@@ -671,7 +671,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 		if (reverse)
 			reverse_track_data(&alt_data[0], data, size, dim);
 		else
-			memcpy(&alt_data[0], data, (size_t)size*dim*dtype_size[dtype]);
+			memcpy(&alt_data[0], data, (size_t)size*dim*dtype_size[as_ordinal(dtype)]);
 
 		// Transform the data if needed
 		if (_data_transform)
@@ -698,7 +698,7 @@ void genome_track::builder::set_data_impl(const interval_t& interval, const T* d
 
 	// If sparsify mode enabled, decode the data block and re-encode only the chunks that are not default_value
 	if (_sparsity_min_run) {
-		encoding::decode_fn decode = _encoding.decoders[dtype][as_ordinal(encoding::layout_t::contiguous)][as_ordinal(pos_strand)];  // decode forward, regardless of interval strand
+		encoding::decode_fn decode = _encoding.decoders[as_ordinal(dtype)][as_ordinal(encoding::layout_t::contiguous)][as_ordinal(pos_strand)];  // decode forward, regardless of interval strand
 		GK_ASSERT(decode);  // should always be a decoder for dtype if there was an encoder
 		if (!alt_data)
 			alt_data = std::make_unique<T[]>((size_t)size*dim);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -104,7 +104,7 @@ template <> bool track_unittest_value_gen<bool>(int value_index, const track_uni
 template <typename data_t>
 void test_genome_track_dtype_etype(genome_track::etype_t etype)
 {
-	print("track_unittest(dtype={}, etype={}) ... ", genome_track::dtype_as_cstr[dtype_traits<data_t>::dtype], genome_track::etype_as_cstr[etype]);
+	print("track_unittest(dtype={}, etype={}) ... ", genome_track::dtype_as_cstr[as_ordinal(dtype_traits<data_t>::dtype)], genome_track::etype_as_cstr[etype]);
 
 	track_unittest_value_range value_ranges[genome_track::num_etype] = {
 		{    1,    1,    1 },  // m0   -- generate [1] always

--- a/src/py_genome_track.cpp
+++ b/src/py_genome_track.cpp
@@ -15,7 +15,7 @@ using etype_t                  = genome_track::dtype_t;
 using dtype_t                  = genome_track::dtype_t;
 static const dtype_t num_dtype = genome_track::num_dtype;
 
-static int py_dtypes[num_dtype] = {
+static int py_dtypes[as_ordinal(num_dtype)] = {
 	NPY_BOOL,  // bool_
 	NPY_UINT8, // uint8
 	NPY_INT8,  // int8
@@ -25,19 +25,19 @@ static int py_dtypes[num_dtype] = {
 
 static PyTypeObject* py_dtype_type(dtype_t dtype)
 {
-	static PyTypeObject* _types[num_dtype] = {
+	static PyTypeObject* _types[as_ordinal(num_dtype)] = {
 		&PyBoolArrType_Type,  // bool_
 		&PyUInt8ArrType_Type, // uint8
 		&PyInt8ArrType_Type,  // int8
 		&PyHalfArrType_Type,  // float16
 		&PyFloatArrType_Type, // float32
 	};
-	return _types[dtype];
+	return _types[as_ordinal(dtype)];
 }
 
 static dtype_t dtype_from_py(int py_dtype)
 {
-	for (int dtype = 0; dtype < num_dtype; ++dtype)
+	for (int dtype = 0; dtype < as_ordinal(num_dtype); ++dtype)
 		if (py_dtypes[dtype] == py_dtype)
 			return (dtype_t)dtype;
 	GK_THROW(type, "data array had unrecognized dtype; try np.bool_, np.uint8, np.int8, np.float16, or np.float32");
@@ -213,7 +213,7 @@ GKPY_OMETHOD_BEGIN(GenomeTrackBuilder, set_data)
 		// Set the data for the given interval using the numpy dtype, if it's supported
 		dtype = dtype_from_py(PyArray_TYPE(py_data));
 		// TODO: handle strided date during encoding
-		size_t stride = genome_track::dtype_size[dtype];
+		size_t stride = genome_track::dtype_size[as_ordinal(dtype)];
 		for (int dim = ndim; dim > 0; --dim) {
 			GK_CHECK((size_t)PyArray_STRIDE(py_data, dim - 1) == stride, value,
 					 "Data must have stride=1, consider making a copy with `np.array`");
@@ -414,7 +414,7 @@ GKPY_OMETHOD_BEGIN(GenomeTrack, Call)
 		// Create an output array of the right type, size, and dimensionality
 		npy_intp dims[2] = {c.size(), self->track->dim()};
 		dtype            = dtype_arg && dtype_arg != Py_None ? dtype_from_obj(dtype_arg) : self->track->dtype();
-		py_dst           = PyArray_Empty(2, dims, PyArray_DescrFromType(py_dtypes[*dtype]), 0);  // 0 => C_CONTIGUOUS
+		py_dst           = PyArray_Empty(2, dims, PyArray_DescrFromType(py_dtypes[as_ordinal(*dtype)]), 0);  // 0 => C_CONTIGUOUS
 		if (!py_dst)
 			return nullptr;  // Propagate the error up to interpreter immediately
 	} else {


### PR DESCRIPTION
the dtype enum is not strongly typed vs an int, so it can get confused with the stride argument:

```
/Users/steve/work/gk-clean/src/genome_track.h:148:7: note: candidate function
        void operator()(const interval_t& c, half_t*  dst, int stride=0) const;
             ^
/Users/steve/work/gk-clean/src/genome_track.h:150:7: note: candidate function
        void operator()(const interval_t& c, void*    dst, dtype_t dtype, int stride=0) const;
```