### PR TITLE
chore: bash syntax error in docs build

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -60,7 +60,7 @@ jobs:
             m2r2 \
             make \
             myst-parser \
-            sphinx<8.0.0 \
+            "sphinx<8.0.0" \
             sphinx_rtd_theme
           set +x
 


### PR DESCRIPTION
introduced in #87 when previously trying to fix the docs build.