### PR TITLE
docs: starter_build script download

### DIFF
--- a/docs-src/quickstart.rst
+++ b/docs-src/quickstart.rst
@@ -36,7 +36,7 @@ them in the local data directory, to get you started. It also serves as a good e
 to build your own data files::
 
     conda activate env-with-genomekit
-    curl -O starter_build.sh https://raw.githubusercontent.com/deepgenomics/GenomeKit/main/starter/build.sh
+    curl -o starter_build.sh https://raw.githubusercontent.com/deepgenomics/GenomeKit/main/starter/build.sh
     chmod +x starter_build.sh
     ./starter_build.sh
 


### PR DESCRIPTION
Windows users at the hackathon had issues with the script since they didn't have `grep` or `wget` from the windows command line, also saw some confusion between windows cmd and powershell users. Don't think it's a huge issue but maybe something to keep in mind since the package can be easily installed on windows but harder to use. 