### PR TITLE
chore: fix windows build

### DIFF
--- a/setup/c_ext.py
+++ b/setup/c_ext.py
@@ -348,9 +348,9 @@ def windows_parallel_ccompile(self,
 
 
 if sys.platform == "win32":
-    import distutils.msvccompiler
+    import distutils._msvccompiler
     import distutils.msvc9compiler
-    distutils.msvccompiler.MSVCCompiler.compile = windows_parallel_ccompile
+    distutils._msvccompiler.MSVCCompiler.compile = windows_parallel_ccompile
     distutils.msvc9compiler.MSVCCompiler.compile = windows_parallel_ccompile
 else:
     distutils.ccompiler.CCompiler.compile = gcc_parallel_ccompile


### PR DESCRIPTION
setuptools broken compat, see https://github.com/pypa/setuptools/pull/4600

Error on latest release attempt: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1071695&view=logs&j=535b614b-9e28-51ef-eb67-d0aa83d01d61&t=c0e5205c-8699-555e-ce93-e93093f402f2&l=29576

setuptools not pinned, changed from 73.0.1 to 75.3.0. Hopefully should work, found similar code in other repos.