### PR TITLE
chore: fix windows build

### DIFF
--- a/setup/c_ext.py
+++ b/setup/c_ext.py
@@ -349,8 +349,6 @@ def windows_parallel_ccompile(self,
 
 if sys.platform == "win32":
     import distutils._msvccompiler
-    import distutils.msvc9compiler
     distutils._msvccompiler.MSVCCompiler.compile = windows_parallel_ccompile
-    distutils.msvc9compiler.MSVCCompiler.compile = windows_parallel_ccompile
 else:
     distutils.ccompiler.CCompiler.compile = gcc_parallel_ccompile


### PR DESCRIPTION
missed in #106 but msvc9compiler is gone

Error log: https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=1072849&view=logs&j=535b614b-9e28-51ef-eb67-d0aa83d01d61&t=c0e5205c-8699-555e-ce93-e93093f402f2&l=29577