### PR TITLE
chore: avoid compilation errors on fmt11

### DIFF
--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -1,3 +1,5 @@
+# this file does not affect the conda-forge build, only the local repos github actions
+# (in particular running unit tests)
 c_stdlib:
 - sysroot # [linux]
 - macosx_deployment_target # [osx]

--- a/genomekit_dev.yml
+++ b/genomekit_dev.yml
@@ -1,6 +1,5 @@
 name: genomekit_dev
 channels:
-  - deepgenomics
   - conda-forge
   - bioconda
 dependencies:

--- a/setup/c_ext.py
+++ b/setup/c_ext.py
@@ -195,6 +195,7 @@ elif toolset == "msvc":
             "/Oy",  # Omit frame pointers
             "/Oi",  # Enable intrinsics
             #"/Zi",  # Enable debug information .pdb
+            "/utf-8" # support fmt11
         ]
         extra_link_args += [
             "/LTCG",  # Enable link-time code generation


### PR DESCRIPTION
see https://github.com/conda-forge/genomekit-feedstock/pull/52#issuecomment-2466914597

Release-As: 6.1.1

also:
- clarify purpose of conda_build_config.yaml
- remove unused private channel from env file