### PR TITLE
chore: don't run unit tests on release-please PRs

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -2,7 +2,6 @@ name: run-unit-tests
 run-name: run unit tests
 on:
   pull_request:
-    branches-ignore: ["release-please*"]
     paths:
     - ".github/actions/**"
     - ".github/workflows/**"
@@ -19,6 +18,7 @@ jobs:
       matrix:
         platform: [["linux-64", "ubuntu-latest"], ["osx-64", "macos-latest"]]
     runs-on: ${{ matrix.platform[1] }}
+    if: "!startsWith(github.head_ref, 'release-please')"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
branches-ignore references the target branch, not the source branch