### PR TITLE
feat: support reference alignment computation for negative stranded intervals

### DIFF
--- a/docs-src/develop.rst
+++ b/docs-src/develop.rst
@@ -38,7 +38,7 @@ by linking your source tree from python's ``site-packages``.
 
 .. note:: Windows Prerequisites
 
-    You will need VS 2019 or newer installed. To get a compatible shell, either locate 
+    You will need VS 2019 or newer installed. To get a compatible shell, either locate
     and run ``vcvars64.bat``, or start the x64 Native Tools Command Prompt from the
     Start menu.
     To open VS with a preconfigured project, directly run in that command prompt::
@@ -47,7 +47,7 @@ by linking your source tree from python's ``site-packages``.
 
 Finally, run the all the tests::
 
-    python -m unittest discover
+    CI=1 python -m unittest discover
 
 You can also run examples from the ``demos`` directory.
 
@@ -74,7 +74,7 @@ yourself. *Forgetting this step may lead to unpredictable behaviour.*
 
 Before checking in any changes, run all tests locally::
 
-    python -m unittest discover
+    CI=1 python -m unittest discover
 
 
 Adding tests

--- a/tests/test_apply_variants.py
+++ b/tests/test_apply_variants.py
@@ -645,24 +645,48 @@ class TestApplyVariants(unittest.TestCase):
 
     def test_reference_alignment_no_anchor(self):
         genome37 = MiniGenome('test_genome')
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37)
+
+        # test a deletion variant
+
         variants = [Variant.from_string("chr1:11:G:-", genome37)]
-        interval = Interval('chr1', '+', 5, 15, genome37)
 
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
-
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual([0, 1, 2, 3, 4, 6, 7, 8, 9], reference_alignment)
 
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual([0, 1, 2, 3, 5, 6, 7, 8, 9], reference_alignment)
+
+        # test a deletion + substitution variant
+
         variants = [Variant.from_string("chr1:11:GTA:TT", genome37)]
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual([0, 1, 2, 3, 4, 5, 6, 8, 9], reference_alignment)
 
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual([0, 1, 3, 4, 5, 6, 7, 8, 9], reference_alignment)
+
+        # test an insertion variant
+
         variants = [Variant.from_string("chr1:11::TT", genome37)]
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual([0, 1, 2, 3, 4, (5, 0), (5, 1), 5, 6, 7, 8, 9], reference_alignment)
 
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual([0, 1, 2, 3, 4, (5, 0), (5, 1), 5, 6, 7, 8, 9], reference_alignment) # TODO: double check
+
+        # test an insertion + substitution variant
+
         variants = [Variant.from_string("chr1:11:G:TT", genome37)]
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual([0, 1, 2, 3, 4, 5, (6, 0), 6, 7, 8, 9], reference_alignment)
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual([0, 1, 2, 3, (4, 0), 4, 5, 6, 7, 8, 9], reference_alignment)
 
     def test_reference_alignment_interior_anchor(self):
         genome37 = MiniGenome('test_genome')
@@ -736,13 +760,13 @@ class TestApplyVariants(unittest.TestCase):
         reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [2, 3, 4, (5, 0), (5, 1), 5, 6, 7, 8, 9])
 
-    def test_reference_alignment_exception(self):
-        genome37 = MiniGenome('test_genome')
-        variants = [Variant.from_string("chr1:11:GTA:ATG", genome37)]
-        interval = Interval('chr1', '-', 5, 15, genome37, 5)
+    # def test_reference_alignment_exception(self): # TODO: remove
+    #     genome37 = MiniGenome('test_genome')
+    #     variants = [Variant.from_string("chr1:11:GTA:ATG", genome37)]
+    #     interval = Interval('chr1', '-', 5, 15, genome37, 5)
 
-        with self.assertRaises(ValueError):
-            apply_variants(genome37.dna, variants, interval, reference_alignment=True)
+    #     with self.assertRaises(ValueError):
+    #         apply_variants(genome37.dna, variants, interval, reference_alignment=True)
 
     def test_variant_on_other_chromosome(self):
         """Tests that variants are only applied when they are on the same

--- a/tests/test_apply_variants.py
+++ b/tests/test_apply_variants.py
@@ -813,14 +813,6 @@ class TestApplyVariants(unittest.TestCase):
         reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, (5, 0), (5, 1), 5, 6, 7])
 
-    # def test_reference_alignment_exception(self): # TODO: remove
-    #     genome37 = MiniGenome('test_genome')
-    #     variants = [Variant.from_string("chr1:11:GTA:ATG", genome37)]
-    #     interval = Interval('chr1', '-', 5, 15, genome37, 5)
-
-    #     with self.assertRaises(ValueError):
-    #         apply_variants(genome37.dna, variants, interval, reference_alignment=True)
-
     def test_variant_on_other_chromosome(self):
         """Tests that variants are only applied when they are on the same
         chromosome as the interval.

--- a/tests/test_apply_variants.py
+++ b/tests/test_apply_variants.py
@@ -260,6 +260,17 @@ class TestApplyVariants(unittest.TestCase):
         self.assertEqual(var_seq_right, var_seq_center)
         self.assertEqual(var_seq_right, 'GTGTGT')
 
+        interval = Interval('chr1', '-', 10, 16, 'test_genome', 10)
+        var_seq_right = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 16, 'test_genome', 16)
+        var_seq_left = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 16, 'test_genome', 13)
+        var_seq_center = apply_variants(self.dna, variants, interval)
+
+        self.assertEqual(var_seq_right, var_seq_left)
+        self.assertEqual(var_seq_right, var_seq_center)
+        self.assertEqual(var_seq_right, _dna_complement('GTGTGT'))
+
     def test_var_upstream(self):
         variants = [Variant.from_string("chr1:4:.:AAAAA", self.genome)]
 
@@ -326,6 +337,17 @@ class TestApplyVariants(unittest.TestCase):
         self.assertEqual(var_seq_left, 'CGACG')
         self.assertEqual(var_seq_left, var_seq_center)
 
+        # Reverse strand
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 10)
+        var_seq_right = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 15)
+        var_seq_left = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 13)
+        var_seq_center = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq_right, _dna_complement('ACGTA'))
+        self.assertEqual(var_seq_left, _dna_complement('CGACG'))
+        self.assertEqual(var_seq_left, var_seq_center)
+
     def test_deletion_overlap_end(self):
         variants = [Variant.from_string("chr1:15:GTA:-", self.genome)]
 
@@ -339,6 +361,18 @@ class TestApplyVariants(unittest.TestCase):
 
         self.assertEqual(var_seq_right, 'GTACC')
         self.assertEqual(var_seq_left, 'CGTAC')
+        self.assertEqual(var_seq_right, var_seq_center)
+
+        # Reverse strand
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 10)
+        var_seq_right = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 15)
+        var_seq_left = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 13)
+        var_seq_center = apply_variants(self.dna, variants, interval)
+
+        self.assertEqual(var_seq_right, _dna_complement('GTACC'))
+        self.assertEqual(var_seq_left, _dna_complement('CGTAC'))
         self.assertEqual(var_seq_right, var_seq_center)
 
     def test_deletion_interior(self):
@@ -355,6 +389,17 @@ class TestApplyVariants(unittest.TestCase):
         self.assertEqual(var_seq_left, 'TACGT')
         self.assertEqual(var_seq_center, 'CGTTA')
 
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 10)
+        var_seq_right = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 15)
+        var_seq_left = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 13)
+        var_seq_center = apply_variants(self.dna, variants, interval)
+
+        self.assertEqual(var_seq_right, _dna_complement('GTTAC'))
+        self.assertEqual(var_seq_left, _dna_complement('TACGT'))
+        self.assertEqual(var_seq_center, _dna_complement('CGTTA'))
+
     def test_indel_overlap_end(self):
         variants = [Variant.from_string("chr1:14:CGTAC:AAAA", self.genome)]
 
@@ -369,6 +414,18 @@ class TestApplyVariants(unittest.TestCase):
         self.assertEqual(var_seq_right, 'GTAAA')
         self.assertEqual(var_seq_left, 'GTAAA')
         self.assertEqual(var_seq_center, 'GTAAA')
+
+        # Reverse strand
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 10)
+        var_seq_right = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 15)
+        var_seq_left = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 13)
+        var_seq_center = apply_variants(self.dna, variants, interval)
+
+        self.assertEqual(var_seq_right, _dna_complement('GTAAA'))
+        self.assertEqual(var_seq_left, _dna_complement('GTAAA'))
+        self.assertEqual(var_seq_center, _dna_complement('GTAAA'))
 
     def test_double_variant(self):
         variants = [
@@ -387,6 +444,17 @@ class TestApplyVariants(unittest.TestCase):
         self.assertEqual(var_seq_left, 'GGAAA')
         self.assertEqual(var_seq_center, 'GGAAA')
 
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 10)
+        var_seq_right = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 15)
+        var_seq_left = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 13)
+        var_seq_center = apply_variants(self.dna, variants, interval)
+
+        self.assertEqual(var_seq_right, _dna_complement('GGAAA'))
+        self.assertEqual(var_seq_left, _dna_complement('GGAAA'))
+        self.assertEqual(var_seq_center, _dna_complement('GGAAA'))
+
     def test_indel_overlap_entire_interval(self):
         variants = [Variant.from_string("chr1:9:ACGTACGT:", self.genome)]
 
@@ -401,20 +469,40 @@ class TestApplyVariants(unittest.TestCase):
         self.assertEqual(var_seq_left, 'NACGT')
         self.assertEqual(var_seq_center, 'CGTAC')
 
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 10)
+        var_seq_right = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 15)
+        var_seq_left = apply_variants(self.dna, variants, interval)
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', 13)
+        var_seq_center = apply_variants(self.dna, variants, interval)
+
+        self.assertEqual(var_seq_right, _dna_complement('ACGTA'))
+        self.assertEqual(var_seq_left, _dna_complement('NACGT'))
+        self.assertEqual(var_seq_center, _dna_complement('CGTAC'))
+
     def test_no_anchor(self):
         variants = [Variant.from_string('chr1:8:TACGTA:-', self.genome)]
 
         interval = Interval('chr1', '+', 20, 30, 'test_genome', None)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, self.dna(interval))
+        interval = Interval('chr1', '-', 20, 30, 'test_genome', None)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, self.dna(interval))
 
         interval = Interval('chr1', '+', 10, 15, 'test_genome', None)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'CG')
+        interval = Interval('chr1', '-', 10, 15, 'test_genome', None)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('CG'))
 
         interval = Interval('chr1', '+', 5, 10, 'test_genome', None)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'CG')
+        interval = Interval('chr1', '-', 5, 10, 'test_genome', None)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('CG'))
 
     def test_insertion_at_anchor(self):
         variant = [Variant.from_string('chr1:21::AGTT', self.genome)]
@@ -423,23 +511,39 @@ class TestApplyVariants(unittest.TestCase):
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual(sequence, 'TACGTAGTTA')
 
+        interval = Interval('chr1', '-', 15, 25, 'test_genome', 20)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(sequence, _dna_complement('TACGTAGTTA'))
+
     def test_insertion_at_anchor_with_offset(self):
         variant = [Variant.from_string('chr1:21::AGTT', self.genome)]
         interval = Interval('chr1', '+', 15, 25, 'test_genome', 20, 2)
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual(sequence, 'CGTAGTTACG')
 
+        interval = Interval('chr1', '-', 15, 25, self.genome, 20, 2)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(sequence, _dna_complement('CGTAGTTACG'))
+
         variant = Variant.from_string("chr1:11::TTTTAGTTTT", self.genome)
         interval = Interval("chr1", "+", 10, 12, 'test_genome', 10, 4)
         sequence = apply_variants(self.dna, [variant], interval)
         self.assertEqual('AG', sequence)
 
+        interval = Interval("chr1", "-", 10, 12, 'test_genome', 10, 4)
+        sequence = apply_variants(self.dna, [variant], interval)
+        self.assertEqual(_dna_complement('AG'), sequence)
+
     def test_anchor_outside_interval(self):
         # Deletion between interval end and anchor
-        interval = Interval('chr1', '+', 10, 14, self.genome, 21)
         variant = Variant('chr1', 16, 'AC', '', self.genome)
+        interval = Interval('chr1', '+', 10, 14, self.genome, 21)
         sequence = apply_variants(self.dna, [variant], interval)
         self.assertEqual(sequence, 'ACGT')
+
+        interval = Interval('chr1', '-', 10, 14, self.genome, 21)
+        sequence = apply_variants(self.dna, [variant], interval)
+        self.assertEqual(sequence, _dna_complement('ACGT'))
 
         # Deletion overlapping the end
         variant = [Variant.from_string('chr1:14:CG:', self.genome)]
@@ -447,11 +551,19 @@ class TestApplyVariants(unittest.TestCase):
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual(sequence, 'ACGT')
 
+        interval = Interval('chr1', '-', 10, 14, 'test_genome', 21)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(sequence, _dna_complement('ACGT'))
+
         # Insertion between interval end and anchor
         variant = [Variant.from_string('chr1:17::TTTTTTT', self.genome)]
         interval = Interval('chr1', '+', 10, 14, 'test_genome', 21)
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual(sequence, 'TTTT')
+
+        interval = Interval('chr1', '-', 10, 14, 'test_genome', 21)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(sequence, _dna_complement('TTTT'))
 
         # Deletion between the anchor and interval start
         variant = [Variant.from_string('chr1:7:GT:', self.genome)]
@@ -459,17 +571,29 @@ class TestApplyVariants(unittest.TestCase):
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual(sequence, 'ACGT')
 
+        interval = Interval('chr1', '-', 10, 14, 'test_genome', 5)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(sequence, _dna_complement('ACGT'))
+
         # Deletion overlapping the start
         variant = [Variant.from_string('chr1:10:CG:', self.genome)]
         interval = Interval('chr1', '+', 10, 14, 'test_genome', 5)
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual(sequence, 'ACGT')
 
+        interval = Interval('chr1', '-', 10, 14, 'test_genome', 5)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(sequence, _dna_complement('ACGT'))
+
         # Insertion between anchor and interval start
         variant = [Variant.from_string('chr1:9::TTTTTTT', self.genome)]
         interval = Interval('chr1', '+', 10, 14, 'test_genome', 5)
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual(sequence, 'TTTT')
+
+        interval = Interval('chr1', '-', 10, 14, 'test_genome', 5)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(sequence, _dna_complement('TTTT'))
 
     def test_insertion_at_interval_ends(self):
         # Test behaviour when insertions occur at the start or
@@ -484,10 +608,18 @@ class TestApplyVariants(unittest.TestCase):
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual('TTTCGTACGT', sequence)
 
+        interval = Interval('chr1', '-', 9, 19, 'test_genome', 9)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(_dna_complement('TTTCGTACGT'), sequence)
+
         # Insertion will be outside interval
         interval = Interval('chr1', '+', 9, 19, 'test_genome', 9, 3)
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual('CGTACGTACG', sequence)
+
+        interval = Interval('chr1', '-', 9, 19, 'test_genome', 9, 3)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(_dna_complement('CGTACGTACG'), sequence)
 
         # Insertion at end
         variant = [Variant.from_string('chr1:20::TTT', self.genome)]
@@ -498,10 +630,18 @@ class TestApplyVariants(unittest.TestCase):
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual('CGTACGTACG', sequence)
 
+        interval = Interval('chr1', '-', 9, 19, 'test_genome', 19)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(_dna_complement('CGTACGTACG'), sequence)
+
         # Insertion will be inside interval
         interval = Interval('chr1', '+', 9, 19, 'test_genome', 19, 3)
         sequence = apply_variants(self.dna, variant, interval)
         self.assertEqual('ACGTACGTTT', sequence)
+
+        interval = Interval('chr1', '-', 9, 19, 'test_genome', 19, 3)
+        sequence = apply_variants(self.dna, variant, interval)
+        self.assertEqual(_dna_complement('ACGTACGTTT'), sequence)
 
     def test_reference_alignment_no_anchor(self):
         genome37 = MiniGenome('test_genome')
@@ -626,15 +766,27 @@ class TestApplyVariants(unittest.TestCase):
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'ATCAT')
 
+        interval = Interval('chr1', '-', 12, 16, 'test_genome')
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('ATCAT'))
+
         # right anchor
         interval = Interval('chr1', '+', 12, 16, 'test_genome', 16)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'TCAT')
 
+        interval = Interval('chr1', '-', 12, 16, 'test_genome', 16)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('TCAT'))
+
         # at anchor
         interval = Interval('chr1', '+', 12, 16, 'test_genome', 13)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'ATCA')
+
+        interval = Interval('chr1', '-', 12, 16, 'test_genome', 13)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('ATCA'))
 
     def test_insertion_and_deletion(self):
         variants = [Variant.from_string('chr1:14::T', self.genome), Variant.from_string('chr1:15:G:', self.genome)]
@@ -645,15 +797,27 @@ class TestApplyVariants(unittest.TestCase):
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'ATCT')
 
+        interval = Interval('chr1', '-', 12, 16, 'test_genome')
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('ATCT'))
+
         # right anchor
         interval = Interval('chr1', '+', 12, 16, 'test_genome', 16)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'ATCT')
 
+        interval = Interval('chr1', '-', 12, 16, 'test_genome', 16)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('ATCT'))
+
         # at anchor
         interval = Interval('chr1', '+', 12, 16, 'test_genome', 13)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'ATCT')
+
+        interval = Interval('chr1', '-', 12, 16, 'test_genome', 13)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('ATCT'))
 
     def test_deletion_and_substitution(self):
         variants = [Variant.from_string('chr1:14:C:', self.genome), Variant.from_string('chr1:15:G:A', self.genome)]
@@ -664,15 +828,27 @@ class TestApplyVariants(unittest.TestCase):
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'AAT')
 
+        interval = Interval('chr1', '-', 12, 16, 'test_genome')
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('AAT'))
+
         # right anchor
         interval = Interval('chr1', '+', 12, 16, 'test_genome', 16)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'TAAT')
 
+        interval = Interval('chr1', '-', 12, 16, 'test_genome', 16)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('TAAT'))
+
         # at anchor
         interval = Interval('chr1', '+', 12, 16, 'test_genome', 13)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'AATA')
+
+        interval = Interval('chr1', '-', 12, 16, 'test_genome', 13)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('AATA'))
 
     def test_substitution_in_extended_interval_from_deletion(self):
         self.assertEqual(self.genome.dna(Interval('chr1', '+', 11, 17, 'test_genome')), 'TACGTA')
@@ -683,11 +859,19 @@ class TestApplyVariants(unittest.TestCase):
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'A')
 
+        interval = Interval('chr1', '-', 14, 15, 'test_genome', 15)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, 'T')
+
         # left anchor
         variants = [Variant.from_string('chr1:14:C:', self.genome), Variant.from_string('chr1:15:G:A', self.genome)]
         interval = Interval('chr1', '+', 14, 15, 'test_genome', 14)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'A')
+
+        interval = Interval('chr1', '-', 14, 15, 'test_genome', 14)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, 'T')
 
     def test_deletion_and_insertion(self):
         variants = [Variant.from_string('chr1:14:C:', self.genome), Variant.from_string('chr1:15::T', self.genome)]
@@ -698,12 +882,28 @@ class TestApplyVariants(unittest.TestCase):
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'TGT')
 
+        interval = Interval('chr1', '-', 13, 16, 'test_genome')
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('TGT'))
+
         # right anchor
         interval = Interval('chr1', '+', 13, 16, 'test_genome', 16)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'TGT')
 
+        interval = Interval('chr1', '-', 13, 16, 'test_genome', 16)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('TGT'))
+
         # at anchor
         interval = Interval('chr1', '+', 13, 16, 'test_genome', 13)
         var_seq = apply_variants(self.dna, variants, interval)
         self.assertEqual(var_seq, 'TGT')
+
+        interval = Interval('chr1', '-', 13, 16, 'test_genome', 13)
+        var_seq = apply_variants(self.dna, variants, interval)
+        self.assertEqual(var_seq, _dna_complement('TGT'))
+
+def _dna_complement(dna: str) -> str:
+    complement = {'A': 'T', 'T': 'A', 'C': 'G', 'G': 'C', 'N': 'N'}
+    return ''.join(reversed([complement[base] for base in dna]))

--- a/tests/test_apply_variants.py
+++ b/tests/test_apply_variants.py
@@ -713,10 +713,15 @@ class TestApplyVariants(unittest.TestCase):
 
         # Test insertion with anchor_offset
         positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 10, 2)
-        variants = [Variant.from_string("chr1:11::TTATT", self.genome)]
-        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 10, 2)
 
+        variants = [Variant.from_string("chr1:11::TTATT", self.genome)]
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [2, 3, 4, (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), 5, 6])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [3, 4, (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), 5, 6, 7])
 
         # Test deletion
         positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 10)

--- a/tests/test_apply_variants.py
+++ b/tests/test_apply_variants.py
@@ -690,32 +690,44 @@ class TestApplyVariants(unittest.TestCase):
 
     def test_reference_alignment_interior_anchor(self):
         genome37 = MiniGenome('test_genome')
-        interval = Interval('chr1', '+', 5, 15, genome37, 10)
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 10)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 10)
 
         # Test insertion
         variants = [Variant.from_string("chr1:11::TT", self.genome)]
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
 
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, (5, 0), (5, 1), 5, 6, 7])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [2, 3, 4, (5, 0), (5, 1), 5, 6, 7, 8, 9])
 
         # Test substitution
         variants = [Variant.from_string("chr1:11:GTA:ATG", genome37)]
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
 
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
         # Test insertion with anchor_offset
-        interval = Interval('chr1', '+', 5, 15, genome37, 10, 2)
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 10, 2)
         variants = [Variant.from_string("chr1:11::TTATT", self.genome)]
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
 
         self.assertEqual(reference_alignment, [2, 3, 4, (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), 5, 6])
 
         # Test deletion
-        interval = Interval('chr1', '+', 5, 15, genome37, 10)
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 10)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 10)
+
         variants = [Variant.from_string("chr1:11:GTA:", genome37)]
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 8, 9, 10, 11, 12])
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [-3, -2, -1, 0, 1, 5, 6, 7, 8, 9])
 
     def test_reference_alignment_other_anchor_cases(self):
         genome37 = MiniGenome('test_genome')

--- a/tests/test_apply_variants.py
+++ b/tests/test_apply_variants.py
@@ -734,43 +734,79 @@ class TestApplyVariants(unittest.TestCase):
         variants = [Variant.from_string("chr1:11:GTA:ATG", genome37)]
 
         # Test anchor==start
-        interval = Interval('chr1', '+', 5, 15, genome37, 5)
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 5)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 5)
 
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
-        # Test anchor==start
-        interval = Interval('chr1', '+', 5, 15, genome37, 15)
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        # Test anchor==end
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 15)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 15)
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
         # Test anchor > end
-        interval = Interval('chr1', '+', 5, 15, genome37, 20)
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 20)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 20)
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
         # Test anchor < start with substitution
-        interval = Interval('chr1', '+', 5, 15, genome37, 0)
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 0)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 0)
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
         # Test anchor < start with substitution
         variants = [Variant.from_string("chr1:11::TT", self.genome)]
-        interval = Interval('chr1', '+', 5, 15, genome37, 0)
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 0)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 0)
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, (5, 0), (5, 1), 5, 6, 7])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [2, 3, 4, (5, 0), (5, 1), 5, 6, 7, 8, 9])
 
         # Test anchor right of deletion
         variants = [Variant.from_string("chr1:11:GT:", self.genome)]
-        interval = Interval('chr1', '+', 5, 15, genome37, 11)
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 11)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 11)
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [-1, 0, 1, 2, 3, 4, 6, 7, 8, 9])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [0, 1, 2, 3, 5, 6, 7, 8, 9, 10])
 
         # Test anchor right of insertion
         variants = [Variant.from_string("chr1:11::TT", self.genome)]
-        interval = Interval('chr1', '+', 5, 15, genome37, 15)
-        reference_alignment = apply_variants(genome37.dna, variants, interval, reference_alignment=True)[1]
+
+        positive_strand_interval = Interval('chr1', '+', 5, 15, genome37, 15)
+        negative_strand_interval = Interval('chr1', '-', 5, 15, genome37, 15)
+
+        reference_alignment = apply_variants(genome37.dna, variants, positive_strand_interval, reference_alignment=True)[1]
         self.assertEqual(reference_alignment, [2, 3, 4, (5, 0), (5, 1), 5, 6, 7, 8, 9])
+
+        reference_alignment = apply_variants(genome37.dna, variants, negative_strand_interval, reference_alignment=True)[1]
+        self.assertEqual(reference_alignment, [0, 1, 2, 3, 4, (5, 0), (5, 1), 5, 6, 7])
 
     # def test_reference_alignment_exception(self): # TODO: remove
     #     genome37 = MiniGenome('test_genome')

--- a/tests/test_interval.py
+++ b/tests/test_interval.py
@@ -568,6 +568,9 @@ class TestInterval(unittest.TestCase):
         self.assertEqual(interval.anchor, 8)
         self.assertEqual(interval.anchor_offset, 0)
 
+        interval = Interval('chr1', '-', 5, 10, 'hg19', 8)
+        self.assertEqual(interval.anchor_offset, 0)
+
         interval = Interval('chr1', '+', 5, 10, 'hg19', 9)
         self.assertEqual(interval.anchor, 9)
         self.assertEqual(interval.anchor_offset, 0)


### PR DESCRIPTION
Fixes #130.

Previously, if a user wanted to get the reference alignment for a negative strand through `apply_variants`, they'd get a ValueError saying that it was not supported. This PR adds support for this feature.

The alignment generation is done by first flipping the positive strand alignment and then translating it so that it is returned in an ascending order.