### PR TITLE
feat: wheel distribution for linux on python 3.9-3.12

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,0 +1,116 @@
+name: build-wheels
+run-name: build-wheels
+
+on:
+  push:
+    # only build+push docker on release-please tags
+    tags: [ "v*" ]
+    paths:
+    - ".github/actions/**"
+    - ".github/workflows/**"
+    - "conda-recipe/**"
+    - "genome_kit/**"
+    - "setup.py"
+    - "setup/**"
+    - "src/**"
+    - "tests/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+        # optional but recommended for speed.
+        # the docker image in the workflow is necessary to build a manylinux compliant wheel.
+        # PyPI expects these to be run in manylinux_2_28 or lower.
+        # additionally, manylinux_2_28 is actively maintained by PyPA and includes /opt/python/ environments
+        # for 3.9-3.12 out-of-the-box.
+      - name: Pre-pull manylinux image
+        run: docker pull quay.io/pypa/manylinux_2_28_x86_64
+
+      - name: Build and repair wheels for Python 3.9–3.12
+        run: |
+          docker run --rm -v $(pwd):/io -e BUILD_WHEELS=1 quay.io/pypa/manylinux_2_28_x86_64 /bin/bash -c "
+            set -euxo pipefail
+
+            PYTHONS=(
+              /opt/python/cp39-cp39/bin/python
+              /opt/python/cp310-cp310/bin/python
+              /opt/python/cp311-cp311/bin/python
+              /opt/python/cp312-cp312/bin/python
+            )
+
+            # Build and install libfmt to statically link to wheel
+            cd /tmp
+            # for now 11.1.4 is broken, otherwise use latest tag
+            git clone --branch 11.0.2 --depth=1 https://github.com/fmtlib/fmt.git
+            cd fmt
+            cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_INSTALL=ON .
+            make -j\$(nproc)
+            make install
+            cd /io
+
+            mkdir -p repaired_wheels
+
+            # install build dependencies
+            # numpy is required at build time because its c api is used
+            for PYTHON in \${PYTHONS[@]}; do
+              \$PYTHON -m pip install -U pip setuptools wheel cmake auditwheel numpy
+
+              # Clean previous build artifacts
+              rm -rf build dist *.egg-info
+
+              # Build wheel
+              \$PYTHON setup.py bdist_wheel
+
+              # Repair wheel to comply with manylinux
+              auditwheel repair dist/*.whl --plat manylinux_2_28_x86_64 -w repaired_wheels
+            done
+          "
+
+      - name: Upload built wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: genomekit-wheels-linux
+          path: repaired_wheels/*.whl
+
+
+      - name: Download built wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: genomekit-wheels-linux
+          path: wheels
+
+      - name: Test wheels across Python 3.9–3.12 with unit tests
+        run: |
+          set -euxo pipefail
+          # for PYVER in 3.10 3.11 3.12; do
+          for PYVER in 3.9 3.10 3.11 3.12; do
+            # Get version tags
+            TAG="cp${PYVER/./}"
+
+            echo "Testing on Python $PYVER with tag $TAG"
+
+            docker run --rm \
+              -v $(pwd)/wheels:/wheels \
+              -v $(pwd)/tests:/tests \
+              python:$PYVER-slim /bin/bash -c "
+                set -euxo pipefail
+
+                apt-get update && apt-get install -y gcc python3-dev
+
+                python -m pip install --upgrade pip
+
+                # Find the matching wheel
+                WHEEL=\$(ls /wheels/*${TAG}*.whl | head -n 1)
+                echo 'Installing wheel: ' \$WHEEL
+                python -m pip install \$WHEEL
+
+                # Run import and unit tests
+                python -c 'import genome_kit; print(genome_kit.__version__)'
+                ls tests/test_*.py | sed 's/\.py$//' | sed 's/tests\//tests./' | CI=1 xargs --verbose -I {} python -m unittest {}
+              "
+          done

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2016-2023 Deep Genomics Inc. All Rights Reserved.
+import os
 
 from setuptools import setup, find_packages
 from setuptools.command.egg_info import egg_info
@@ -28,6 +29,18 @@ class egg_info_ex(egg_info):
         egg_info.run(self)
 
 if __name__ == "__main__":
+    install_requires = []
+    if os.environ.get("BUILD_WHEELS", None) is not None:
+        install_requires = [
+            "appdirs>=1.4.0",
+            "numpy<2.0dev0",
+            "google-cloud-storage>=2.10.0",
+            "boto3",
+            "tqdm",
+            "setuptools",
+            "importlib-metadata",
+            "typing-extensions",
+        ]
     setup(
         author="Deep Genomics",
         author_email="info@deepgenomics.com",
@@ -41,6 +54,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.12",
         ],
         description="GenomeKit is a Python library for fast and easy access to genomic resources such as sequence, data tracks, and annotations.",
+        install_requires=install_requires,
         license="Apache License 2.0",
         license_files=(COPYRIGHT_FILE, LICENSE_FILE,),
         name="genomekit",


### PR DESCRIPTION
added github workflow for building and testing python wheels for GK, thus far for `manylinux_2_28_x86` and Python `3.9-3.12`. Comments on specific steps in the workflow are included in the `.yaml`. Below are some more detailed comments on major decisions:

[build-wheels.yaml]

line 21: docker linux image `quay.io/pypa/manylinux_2_28_x86_64`

- the docker image in the workflow is necessary to build a manylinux compliant wheel.
- PyPI expects build to be run in `manylinux_2_28` or lower, so `manylinux_2_28` image is chosen for uploading to PyPI (which will be implemented in future PR).
- additionally, `manylinux_2_28` is actively maintained by PyPA and includes `/opt/python/` environments for 3.9-3.12 out-of-the-box. 


line 36-43: statically link libfmt to wheel

- `libfmt` is compiled and installed from source in the docker image. 
- dynamic linking was explored (`libfmt` would have its own `.so` file bundled into the wheel). 
   - the `libfmt.so` file would not get bundled by default
   - repairing the wheel with auditwheel to bundle all `.so` files generated would wrongly include `.so` system files (ex. `libstdc++.so`) which are platform-specific and should not be bundled. 
   - also violates `PEP 599` and `auditwheel` best practices. 
   - forcefully removing only the system `.so` files results in Import Errors:
```
File "/usr/local/lib/python3.12/site-packages/genome_kit/gk_data.py", line 29, in <module>
	from . import _cxx
ImportError: libstdc++-a68762c8.so.6.0.33: cannot open shared object file: No such file or directory
```

- thus `libfmt` is statically linked. This step in the workflow can be removed once use of fmt is replaced by `std::format`. 


line 50: installing build dependencies

- `numpy` is required at build time because its c api is used (`#include <numpy/arrayobject.h>`)
- build dependencies can usually be specified in `pyproject.toml` however as explained below `pyproject.toml` is not read correctly when building by `python setup.py bdist_wheel`.
- note that this is no longer relevant as `pyproject.toml` has been removed.


line 56: building the wheel

- modern practice is to build wheels with `python -m build` (for both source distribution and wheel) or `python -m build --wheel` (for just the wheel). 
- issue is `python -m build --wheel` runs in an isolated environment so `from setup import c_ext` fails. 
- supposed to be able to declare `/setup` and its contents in `MANIFEST.in` to copy over into this env but doesn't work for some reason. 
- The alternatives below also failed.
   - tried `sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))` quick fix to `PEP517`.
   - tried including `c_ext.py` in `MANIFEST.in` directly.
   - tried importing (`from setup import c_ext`) inside `if __name__ == "__main__":` in `setup.py` to make sure build environment is fully configured before attempting an import.

- `setup.py bdist_wheel` on the other hand works because it runs directly from the root, so has full visibility of `/setup` directory. 
- this method of building wheels does not need nor use the `pyproject.toml` (supposedly) as it is a legacy build system and is not `PEP 517`-complient and doesn't abide by `PEP 517/518` isolation rules. 
- since `[build-system] requires` tag gets completely ignored in `pyproject.toml`, I have to install `numpy` at build time. 
- however I discovered that `pyproject.toml` does not get completely ignored. specifying `[project] dependencies` works somehow. 
- commenting out / deleting `pyproject.toml` results in runtime dependencies not being installed and bundled. 
- this means the runtime dependencies can be specifed in `pyproject.toml` and not necessarily in `setup.py` as `install_requires` where it will interfere with conda packaging.
- as mentioned since `pyproject.toml` has been removed, run-time dependencies are now specified in `setup.py`. 
   - environment variable `BUILD_WHEELS` is used in conjunction with `install_requires=` attribute in `setup` not to interfere with conda packaging. 