### PR TITLE
feat: wheel distribution for linux arm architecture

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -1,0 +1,116 @@
+name: build-wheels
+run-name: build-wheels
+
+on:
+  push:
+    # only build+push docker on release-please tags
+    tags: [ "v*" ]
+    paths:
+    - ".github/actions/**"
+    - ".github/workflows/**"
+    - "conda-recipe/**"
+    - "genome_kit/**"
+    - "setup.py"
+    - "setup/**"
+    - "src/**"
+    - "tests/**"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+        # optional but recommended for speed.
+        # the docker image in the workflow is necessary to build a manylinux compliant wheel.
+        # PyPI expects these to be run in manylinux_2_28 or lower.
+        # additionally, manylinux_2_28 is actively maintained by PyPA and includes /opt/python/ environments
+        # for 3.9-3.12 out-of-the-box.
+      - name: Pre-pull manylinux image
+        run: docker pull quay.io/pypa/manylinux_2_28_x86_64
+
+      - name: Build and repair wheels for Python 3.9–3.12
+        run: |
+          docker run --rm -v $(pwd):/io -e BUILD_WHEELS=1 quay.io/pypa/manylinux_2_28_x86_64 /bin/bash -c "
+            set -euxo pipefail
+
+            PYTHONS=(
+              /opt/python/cp39-cp39/bin/python
+              /opt/python/cp310-cp310/bin/python
+              /opt/python/cp311-cp311/bin/python
+              /opt/python/cp312-cp312/bin/python
+            )
+
+            # Build and install libfmt to statically link to wheel
+            cd /tmp
+            # for now 11.1.4 is broken, otherwise use latest tag
+            git clone --branch 11.0.2 --depth=1 https://github.com/fmtlib/fmt.git
+            cd fmt
+            cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_INSTALL=ON .
+            make -j\$(nproc)
+            make install
+            cd /io
+
+            mkdir -p repaired_wheels
+
+            # install build dependencies
+            # numpy is required at build time because its c api is used
+            for PYTHON in \${PYTHONS[@]}; do
+              \$PYTHON -m pip install -U pip setuptools wheel cmake auditwheel numpy
+
+              # Clean previous build artifacts
+              rm -rf build dist *.egg-info
+
+              # Build wheel
+              \$PYTHON setup.py bdist_wheel
+
+              # Repair wheel to comply with manylinux
+              auditwheel repair dist/*.whl --plat manylinux_2_28_x86_64 -w repaired_wheels
+            done
+          "
+
+      - name: Upload built wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: genomekit-wheels-linux
+          path: repaired_wheels/*.whl
+
+
+      - name: Download built wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: genomekit-wheels-linux
+          path: wheels
+
+      - name: Test wheels across Python 3.9–3.12 with unit tests
+        run: |
+          set -euxo pipefail
+          # for PYVER in 3.10 3.11 3.12; do
+          for PYVER in 3.9 3.10 3.11 3.12; do
+            # Get version tags
+            TAG="cp${PYVER/./}"
+
+            echo "Testing on Python $PYVER with tag $TAG"
+
+            docker run --rm \
+              -v $(pwd)/wheels:/wheels \
+              -v $(pwd)/tests:/tests \
+              python:$PYVER-slim /bin/bash -c "
+                set -euxo pipefail
+
+                apt-get update && apt-get install -y gcc python3-dev
+
+                python -m pip install --upgrade pip
+
+                # Find the matching wheel
+                WHEEL=\$(ls /wheels/*${TAG}*.whl | head -n 1)
+                echo 'Installing wheel: ' \$WHEEL
+                python -m pip install \$WHEEL
+
+                # Run import and unit tests
+                python -c 'import genome_kit; print(genome_kit.__version__)'
+                ls tests/test_*.py | sed 's/\.py$//' | sed 's/tests\//tests./' | CI=1 xargs --verbose -I {} python -m unittest {}
+              "
+          done

--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -114,3 +114,89 @@ jobs:
                 ls tests/test_*.py | sed 's/\.py$//' | sed 's/tests\//tests./' | CI=1 xargs --verbose -I {} python -m unittest {}
               "
           done
+
+  build-arm:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU for ARM emulation
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Pre-pull manylinux image for ARM
+        run: docker pull quay.io/pypa/manylinux_2_28_aarch64
+
+      - name: Build and repair ARM wheels for Python 3.9–3.12
+        run: |
+          docker run --rm -v $(pwd):/io quay.io/pypa/manylinux_2_28_aarch64 /bin/bash -c "
+            set -euxo pipefail
+
+            PYTHONS=(
+              /opt/python/cp39-cp39/bin/python
+              /opt/python/cp310-cp310/bin/python
+              /opt/python/cp311-cp311/bin/python
+              /opt/python/cp312-cp312/bin/python
+            )
+
+            cd /tmp
+            git clone --branch 11.0.2 --depth=1 https://github.com/fmtlib/fmt.git
+            cd fmt
+            cmake -DCMAKE_POSITION_INDEPENDENT_CODE=TRUE -DFMT_INSTALL=ON .
+            make -j\$(nproc)
+            make install
+            cd /io
+
+            mkdir -p repaired_wheels
+
+            for PYTHON in \${PYTHONS[@]}; do
+              \$PYTHON -m pip install -U pip setuptools wheel cmake auditwheel numpy
+              rm -rf build dist *.egg-info
+              \$PYTHON setup.py bdist_wheel
+              auditwheel repair dist/*.whl --plat manylinux_2_28_aarch64 -w repaired_wheels
+            done
+          "
+
+      - name: Upload ARM wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: genomekit-wheels-arm
+          path: repaired_wheels/*.whl
+
+      - name: Download ARM wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: genomekit-wheels-arm
+          path: wheels
+
+      - name: Test ARM wheels across Python 3.9–3.12
+        run: |
+          set -euxo pipefail
+
+          for PYVER in 3.9 3.10 3.11 3.12; do
+            TAG="cp${PYVER/./}"  # 3.9 -> cp39, etc.
+
+            echo "Testing on Python $PYVER (arm64)"
+
+            docker run --rm \
+              --platform linux/arm64 \
+              -v $(pwd)/wheels:/wheels \
+              -v $(pwd)/tests:/tests \
+              arm64v8/python:$PYVER-slim /bin/bash -c "
+                set -euxo pipefail
+
+                apt-get update && apt-get install -y gcc python3-dev
+
+                python -m pip install --upgrade pip
+
+                WHEEL=\$(ls /wheels/*${TAG}*.whl | head -n 1)
+                echo 'Installing wheel: ' \$WHEEL
+                python -m pip install \$WHEEL
+
+                python -c 'import genome_kit; print(genome_kit.__version__)'
+                ls /tests/test_*.py | sed 's/\.py$//' | sed 's/\/tests\//tests./' | CI=1 xargs --verbose -I {} python -m unittest {}
+              "
+          done

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2016-2023 Deep Genomics Inc. All Rights Reserved.
+import os
 
 from setuptools import setup, find_packages
 from setuptools.command.egg_info import egg_info
@@ -28,6 +29,18 @@ class egg_info_ex(egg_info):
         egg_info.run(self)
 
 if __name__ == "__main__":
+    install_requires = []
+    if os.environ.get("BUILD_WHEELS", None) is not None:
+        install_requires = [
+            "appdirs>=1.4.0",
+            "numpy<2.0dev0",
+            "google-cloud-storage>=2.10.0",
+            "boto3",
+            "tqdm",
+            "setuptools",
+            "importlib-metadata",
+            "typing-extensions",
+        ]
     setup(
         author="Deep Genomics",
         author_email="info@deepgenomics.com",
@@ -41,6 +54,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.12",
         ],
         description="GenomeKit is a Python library for fast and easy access to genomic resources such as sequence, data tracks, and annotations.",
+        install_requires=install_requires,
         license="Apache License 2.0",
         license_files=(COPYRIGHT_FILE, LICENSE_FILE,),
         name="genomekit",


### PR DESCRIPTION
Follow up to [PR #147](https://github.com/deepgenomics/GenomeKit/pull/147). 

Added a job in `build-wheels.yaml` workflow to build wheels for `manylinux_2_28_aarch64` for Python 3.9-3.12. Steps follow the same reasoning as explain in [PR #147](https://github.com/deepgenomics/GenomeKit/pull/147) for the most part. 

- `QEMU` is used for ARM emulation inside the Docker image.
   - this is necessary because GitHub Actions runners, `ubuntu-latest` in this case, are `x86_64` only. 
   - for the same reason an ARM Docker image like `arm64v8/python` won't run, hence the emulation. 