### PR TITLE
feat: wheel distribution for linux on python 3.9-3.12, arm architecture

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -6,14 +6,14 @@ on:
     # only build+publish wheels on release-please tags
     tags: [ "v*" ]
     paths:
-    - ".github/actions/**"
-    - ".github/workflows/**"
-    - "conda-recipe/**"
-    - "genome_kit/**"
-    - "setup.py"
-    - "setup/**"
-    - "src/**"
-    - "tests/**"
+      - ".github/actions/**"
+      - ".github/workflows/**"
+      - "conda-recipe/**"
+      - "genome_kit/**"
+      - "setup.py"
+      - "setup/**"
+      - "src/**"
+      - "tests/**"
 
 jobs:
   build:
@@ -56,7 +56,7 @@ jobs:
 
               # Build wheel
               \$PYTHON setup.py bdist_wheel
-          
+
               # Copy wheel to shared folder
               cp dist/*.whl wheels/
             done
@@ -65,7 +65,6 @@ jobs:
       - name: Test wheels across Python 3.9–3.12 with unit tests
         run: |
           set -euxo pipefail
-          # for PYVER in 3.10 3.11 3.12; do
           for PYVER in 3.9 3.10 3.11 3.12; do
             # Get version tags
             TAG="cp${PYVER/./}"
@@ -88,6 +87,77 @@ jobs:
                 python -m pip install \$WHEEL
 
                 # Run import and unit tests
+                python -c 'import genome_kit; print(genome_kit.__version__)'
+                ls /tests/test_*.py | sed 's/\.py$//' | sed 's/\/tests\//tests./' | CI=1 xargs --verbose -I {} python -m unittest {}
+              "
+          done
+
+  build-arm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU for ARM emulation
+        uses: docker/setup-qemu-action@v3
+
+      - name: Pre-pull manylinux aarch64 image
+        run: docker pull quay.io/pypa/manylinux_2_28_aarch64
+
+      - name: Build and repair wheels for ARM (Python 3.9–3.12)
+        run: |
+          docker run --rm --platform linux/arm64 \
+            -v $(pwd):/io \
+            -e GK_BUILD_WHEELS=1 \
+            quay.io/pypa/manylinux_2_28_aarch64 /bin/bash -c "
+              set -euxo pipefail
+          
+              PYTHONS=(
+                /opt/python/cp39-cp39/bin/python
+                /opt/python/cp310-cp310/bin/python
+                /opt/python/cp311-cp311/bin/python
+                /opt/python/cp312-cp312/bin/python
+              )
+          
+              cd /io
+              mkdir -p wheels/arm
+          
+              for PYTHON in \${PYTHONS[@]}; do
+                \$PYTHON -m pip install -U pip setuptools wheel cmake auditwheel \"numpy==2\"
+          
+                rm -rf build dist *.egg-info
+          
+                \$PYTHON setup.py bdist_wheel
+          
+                # separate dir to x86 wheels
+                cp dist/*.whl wheels/arm/
+              done
+            "
+
+      - name: Test ARM wheels across Python 3.9–3.12 with unit tests
+        run: |
+          set -euxo pipefail
+
+          for PYVER in 3.9 3.10 3.11 3.12; do
+            TAG="cp${PYVER/./}"
+
+            echo "Testing on Python $PYVER (ARM64) with tag $TAG"
+
+            docker run --rm \
+              --platform linux/arm64 \
+              -v $(pwd)/wheels/arm:/wheels \
+              -v $(pwd)/tests:/tests \
+              python:$PYVER-slim /bin/bash -c "
+                set -euxo pipefail
+
+                apt-get update && apt-get install -y gcc python3-dev
+
+                python -m pip install --upgrade pip
+
+                WHEEL=\$(ls /wheels/*${TAG}*.whl | head -n 1)
+                echo 'Installing wheel: ' \$WHEEL
+                python -m pip install \$WHEEL
+
                 python -c 'import genome_kit; print(genome_kit.__version__)'
                 ls /tests/test_*.py | sed 's/\.py$//' | sed 's/\/tests\//tests./' | CI=1 xargs --verbose -I {} python -m unittest {}
               "


### PR DESCRIPTION
added to `build-wheels.yaml` workflow for `manylinux_2_28_aarch64` and Python 3.9-3.12. Comments on specific steps in the workflow are included in the .yaml and inline with code changes. Process for building and testing ARM based wheels is identical to those for x86 architecture with the exception of having to use `QEMU` for ARM emulation since GitHub actions' `ubuntu-latest` is implicitly x86. 
Detailed explanations for choices made can be found in the discussion under [PR#150](https://github.com/deepgenomics/GenomeKit/pull/150).
