### PR TITLE
build: allow quick iteration on meta.yaml

### DIFF
--- a/.github/actions/curl-meta-yaml/action.yaml
+++ b/.github/actions/curl-meta-yaml/action.yaml
@@ -5,21 +5,39 @@ runs:
   steps:
     - shell: bash -l -e {0}
       run: |
+        # Fail if on main branch and conda-recipe/meta.yaml exists
+        if [[ "${GITHUB_REF_NAME}" == "main" && -f "conda-recipe/meta.yaml" ]]; then
+          echo "ERROR: conda-recipe/meta.yaml should not be committed to main. Failing build."
+          exit 1
+        fi
+
         set -x
         mkdir -p conda-recipe
+
+        # If meta.yaml exists, use it directly without modifications
+        if [[ -f "conda-recipe/meta.yaml" ]]; then
+          echo "WARN: Using existing conda-recipe/meta.yaml file"
+          set +x
+          exit 0
+        fi
+
         curl -s -L -o conda-recipe/meta.yaml https://raw.githubusercontent.com/conda-forge/genomekit-feedstock/main/recipe/meta.yaml
         export GK_VERSION=$(grep "version = " setup.py | awk -F'"' '{print $2}')
 
         export OS_TYPE=$(uname)
-        # - replace the (non-existent) tarball with local path
-        # - remove the related sha for that tarball
-        # - build for all locally allowed versions of python (conda-recipe/conda_build_config.yaml)
-        # - set the version to the local release-please version (for docs and docker publish)
         if [[ "$OS_TYPE" == "Darwin" ]]; then
-          sed -i '' -E "s|url: https://github.com/deepgenomics/GenomeKit/archive/refs/tags/v.*$|path: ../|1; /sha256: /d; /skip: true /d;s/{% set version = \".+\" %}/{% set version = \"${GK_VERSION}\" %}/" conda-recipe/meta.yaml
+          SED_CMD="sed -i '' -E"
         else
-          sed -i -e    "s|url: https://github.com/deepgenomics/GenomeKit/archive/refs/tags/v.*$|path: ../|1; /sha256: /d; /skip: true /d;s/{% set version = \".\+\" %}/{% set version = \"${GK_VERSION}\" %}/" conda-recipe/meta.yaml
+          SED_CMD="sed -i"
         fi
+        # replace the (non-existent) tarball with local path
+        $SED_CMD "s|url: https://github.com/deepgenomics/GenomeKit/archive/refs/tags/v.*$|path: ../|1" conda-recipe/meta.yaml
+        # remove the related sha for that tarball
+        $SED_CMD "/sha256: /d" conda-recipe/meta.yaml
+        # build for all locally allowed versions of python (conda-recipe/conda_build_config.yaml)
+        $SED_CMD "/skip: true /d" conda-recipe/meta.yaml
+        # set the version to the local release-please version (for docs and docker publish)
+        $SED_CMD "s/{% set version = \".+\" %}/{% set version = \"${GK_VERSION}\" %}/" conda-recipe/meta.yaml
 
         head -10 conda-recipe/meta.yaml
         set +x

--- a/.github/actions/curl-meta-yaml/action.yaml
+++ b/.github/actions/curl-meta-yaml/action.yaml
@@ -14,14 +14,13 @@ runs:
         set -x
         mkdir -p conda-recipe
 
-        # If meta.yaml exists, use it directly without modifications
+        # If meta.yaml exists, use it (to allow quick iteration in feature branches)
         if [[ -f "conda-recipe/meta.yaml" ]]; then
-          echo "WARN: Using existing conda-recipe/meta.yaml file"
-          set +x
-          exit 0
+          echo "WARN: Using existing conda-recipe/meta.yaml"
+        else
+          curl -s -L -o conda-recipe/meta.yaml https://raw.githubusercontent.com/conda-forge/genomekit-feedstock/main/recipe/meta.yaml
         fi
 
-        curl -s -L -o conda-recipe/meta.yaml https://raw.githubusercontent.com/conda-forge/genomekit-feedstock/main/recipe/meta.yaml
         export GK_VERSION=$(grep "version = " setup.py | awk -F'"' '{print $2}')
 
         export OS_TYPE=$(uname)


### PR DESCRIPTION
Normally meta.yaml is downloaded from the feedstock repo.
Allow quick iteration on meta.yaml in feature branches, while still failing the build if meta.yaml is accidentally committed to main.