### PR TITLE
fix: propagate errors when datamanager fails to resolve paths for a refg

### DIFF
--- a/src/refg.cpp
+++ b/src/refg.cpp
@@ -40,8 +40,10 @@ refg_t refg_registry_t::as_refg(std::string_view config) const
 		std::string config_path{std::format("{}.cfg", config)};
 		try {
 			config_path = resolve_datafile_path(prepend_dir(data_dir(), config_path));
-		} catch (const value_error& e) {
 		}
+		GK_RETHROW(
+			"Could not resolve path: {}\nfor annotation: {}\nThis may result from an error within the datamanger",
+			config, config_path);
 		try {
 			for (line_reader lr{config_path}; !lr.done(); ++lr) {
 				string_view k_v[2];

--- a/src/refg.cpp
+++ b/src/refg.cpp
@@ -42,7 +42,7 @@ refg_t refg_registry_t::as_refg(std::string_view config) const
 			config_path = resolve_datafile_path(prepend_dir(data_dir(), config_path));
 		}
 		GK_RETHROW(
-			"Could not resolve path: {}\nfor annotation: {}\nThis may result from an error within the datamanger",
+			"Could not resolve path: {}\nfor annotation: {}\nThis may result from an error within the datamanager",
 			config_path, config);
 		try {
 			for (line_reader lr{config_path}; !lr.done(); ++lr) {

--- a/src/refg.cpp
+++ b/src/refg.cpp
@@ -43,7 +43,7 @@ refg_t refg_registry_t::as_refg(std::string_view config) const
 		}
 		GK_RETHROW(
 			"Could not resolve path: {}\nfor annotation: {}\nThis may result from an error within the datamanger",
-			config, config_path);
+			config_path, config);
 		try {
 			for (line_reader lr{config_path}; !lr.done(); ++lr) {
 				string_view k_v[2];


### PR DESCRIPTION
Fixes #171 

If the datamanager failed when trying to resolve the path, the stack trace would get swallowed and the code would attempt to load the non-existent `.cfg` in order to parse it. This would then fail since the file doesn't exist, and print the misleading error message.