### PR TITLE
fix: build all supported MANE annotations

### DIFF
--- a/genome_kit/_build_mane.py
+++ b/genome_kit/_build_mane.py
@@ -21,12 +21,6 @@ _SUPPORTED_MANE_VERSIONS_BY_ANNO = {
     "gencode.v46": "1.3",
 }
 
-_SUPPORTED_ANNOS = {
-    "ncbi_refseq.hg38.p14_RS_2024_08": "1.4",
-    "gencode.v41": "1.0",
-}
-
-
 def get_mane_version(annotation):
     """
     Get the MANE version based on the annotation version.
@@ -117,7 +111,7 @@ def build_mane(mane_version: str, genome: gk.Genome):
 
 
 def build_full_mane_files(upload: bool = False):
-    for anno in _SUPPORTED_ANNOS:
+    for anno in _SUPPORTED_MANE_VERSIONS_BY_ANNO:
         genome = gk.Genome(anno)
         res = build_mane(get_mane_version(anno), genome)
         output_filename = get_mane_filename(anno)
@@ -167,5 +161,5 @@ def build_test_mane_file(mane_version, annotation):
 
 def build_test_mane_files():
     os.environ["GENOMEKIT_QUIET"] = "1"
-    for anno, mane_ver in _SUPPORTED_ANNOS.items():
+    for anno, mane_ver in _SUPPORTED_MANE_VERSIONS_BY_ANNO.items():
         build_test_mane_file(mane_ver, anno + ".mini")

--- a/src/refg.cpp
+++ b/src/refg.cpp
@@ -59,7 +59,7 @@ refg_t refg_registry_t::as_refg(std::string_view config) const
 	const refg_t ref{fnv1a_hash64(name)};
 
 	const auto [config_it, config_inserted] = _refg_by_config.try_emplace(std::string{config}, ref);
-	GK_CHECK(config_inserted, runtime, "hash collision, try renaming one of the annotations: '{}' and '{} on '{}'",
+	GK_CHECK(config_inserted, runtime, "hash collision, try renaming one of the annotations: '{}' and '{}' on '{}'",
 			 config_it->first, config, name);
 	const auto [name_it, name_inserted] = _names_by_refg.try_emplace(ref, name);
 	GK_CHECK(name_inserted || name_it->second == name, runtime,


### PR DESCRIPTION
no need for 2 separate mappings

Noticed that gencode.v46 MANE wasn't available.
Map duplicity introduced in #157.