### PR TITLE
chore: fix publish-docs github action

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -4,11 +4,6 @@ on:
   push:
     # only build and publish docs on release-please tags
     tags: ["v*"]
-    paths:
-      - "docs/**"
-      - "genome_kit/**"
-      - ".github/workflows/publish-docs.yaml"
-      - ".github/actions/**"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
docs haven't been published since 7.2.1

I suspect GH behavior changed and now it ignores tag pushes unless path filters match.

fixes #218

Release-As: 7.4.1