### PR TITLE
chore: fix CI for release-please tag triggers

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -5,15 +5,6 @@ on:
   push:
     # only build+push docker on release-please tags
     tags: [ "v*" ]
-    paths:
-    - ".github/actions/**"
-    - ".github/workflows/**"
-    - "genome_kit/**"
-    - "setup.py"
-    - "pyproject.toml"
-    - "setup/**"
-    - "src/**"
-    - "tests/**"
 
 jobs:
   build-wheel-linux:

--- a/.github/workflows/dockerize.yaml
+++ b/.github/workflows/dockerize.yaml
@@ -4,15 +4,6 @@ on:
   push:
     # only build+push docker on release-please tags
     tags: ["v*"]
-    paths:
-    - ".github/actions/**"
-    - ".github/workflows/**"
-    - "conda-recipe/**"
-    - "genome_kit/**"
-    - "setup.py"
-    - "setup/**"
-    - "src/**"
-    - "tests/**"
 
 jobs:
   docker-build:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: python
+          token: ${{ secrets.GK_RELEASE_TOKEN }}


### PR DESCRIPTION
related actions (publish-docs, build-wheels, dockerize) have has been affected since we migrated to release-please github action in #184

fixes #218

- use a separate token to allow trigger of a workflow from the release-please workflow
- remove path trigger because it is AND-ed with the tag and thus would never be invoked.

Release-As: 7.4.2