### PR TITLE
chore: macos-13 github actions builder no longer available

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -114,7 +114,7 @@ jobs:
         env:
           GK_BUILD_WHEELS: "1"
           CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-*"
 
       - if: ${{ steps.restore_macos_wheels.outputs.cache-hit != 'true' }}
         name: cache macos wheels
@@ -132,13 +132,13 @@ jobs:
     strategy:
       matrix:
         include:
-          # macos-14 == arm64, macos-13 == x86_64
+          # macos-14 == arm64, macos-15-intel == x86_64
           - {"os": "macos-14", "arch": "arm64", "pyver": "3.10", "pyvershort": "310"}
           - {"os": "macos-14", "arch": "arm64", "pyver": "3.11", "pyvershort": "311"}
           - {"os": "macos-14", "arch": "arm64", "pyver": "3.12", "pyvershort": "312"}
-          - {"os": "macos-13", "arch": "x86_64", "pyver": "3.10", "pyvershort": "310"}
-          - {"os": "macos-13", "arch": "x86_64", "pyver": "3.11", "pyvershort": "311"}
-          - {"os": "macos-13", "arch": "x86_64", "pyver": "3.12", "pyvershort": "312"}
+          - {"os": "macos-15-intel", "arch": "x86_64", "pyver": "3.10", "pyvershort": "310"}
+          - {"os": "macos-15-intel", "arch": "x86_64", "pyver": "3.11", "pyvershort": "311"}
+          - {"os": "macos-15-intel", "arch": "x86_64", "pyver": "3.12", "pyvershort": "312"}
 
     steps:
       - name: Set up Python


### PR DESCRIPTION
https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

also: remove errant py39 config (harmless)

Release-As: 7.4.4