### PR TITLE
chore: support py313

### DIFF
--- a/.github/workflows/build-wheels.yaml
+++ b/.github/workflows/build-wheels.yaml
@@ -44,7 +44,7 @@ jobs:
         run: python -m cibuildwheel --output-dir wheelhouse && ls -l wheelhouse/
         env:
           GK_BUILD_WHEELS: "1"
-          CIBW_BUILD: "cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
           CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
@@ -52,11 +52,11 @@ jobs:
           CIBW_SKIP: "*-musllinux_*"
 
       - if: ${{ steps.restore_linux_wheels.outputs.cache-hit != 'true' }}
-        name: Test wheels across Python 3.10–3.12
+        name: Test wheels across Python 3.10–3.13
         run: |
           set -euxo pipefail
 
-          for PYVER in 3.10 3.11 3.12; do
+          for PYVER in 3.10 3.11 3.12 3.13; do
             PYVER_SHORT=${PYVER/./}
             echo "Testing on Python $PYVER"
 
@@ -114,7 +114,7 @@ jobs:
         env:
           GK_BUILD_WHEELS: "1"
           CIBW_ARCHS_MACOS: x86_64 arm64
-          CIBW_BUILD: "cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
 
       - if: ${{ steps.restore_macos_wheels.outputs.cache-hit != 'true' }}
         name: cache macos wheels
@@ -136,9 +136,11 @@ jobs:
           - {"os": "macos-14", "arch": "arm64", "pyver": "3.10", "pyvershort": "310"}
           - {"os": "macos-14", "arch": "arm64", "pyver": "3.11", "pyvershort": "311"}
           - {"os": "macos-14", "arch": "arm64", "pyver": "3.12", "pyvershort": "312"}
+          - {"os": "macos-14", "arch": "arm64", "pyver": "3.13", "pyvershort": "313"}
           - {"os": "macos-15-intel", "arch": "x86_64", "pyver": "3.10", "pyvershort": "310"}
           - {"os": "macos-15-intel", "arch": "x86_64", "pyver": "3.11", "pyvershort": "311"}
           - {"os": "macos-15-intel", "arch": "x86_64", "pyver": "3.12", "pyvershort": "312"}
+          - {"os": "macos-15-intel", "arch": "x86_64", "pyver": "3.13", "pyvershort": "313"}
 
     steps:
       - name: Set up Python

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -38,7 +38,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         platform: ["linux-64", "osx-arm64", "osx-64"]
         extras: ["none", "df"]
         rosetta: ["false"]
@@ -49,6 +49,8 @@ jobs:
             pyver-short: "311"
           - python-version: "3.12"
             pyver-short: "312"
+          - python-version: "3.13"
+            pyver-short: "313"
           - platform: "osx-arm64"
             runs-on: "macos-latest"
           - platform: "osx-64"

--- a/conda-recipe/conda_build_config.yaml
+++ b/conda-recipe/conda_build_config.yaml
@@ -7,7 +7,13 @@ c_stdlib_version:
 - '2.17' # [linux]
 - '14.5' # [osx]
 python:
-- '3.9'
 - '3.10'
 - '3.11'
 - '3.12'
+- '3.13'
+
+# Override the default conda-forge numpy pin (which may resolve to 1.26.*
+# depending on the conda-forge-pinning version installed in the build env).
+# numpy 1.26 has no Python 3.13 builds, so we pin to 2.x explicitly.
+numpy:
+- '2'

--- a/genomekit_dev.yml
+++ b/genomekit_dev.yml
@@ -4,8 +4,8 @@ channels:
   - bioconda
 dependencies:
   - appdirs>=1.4.0
-  - numpy <2.0dev0
-  - python>=3.9.0,<3.13.0
+  - numpy >=2.0
+  - python>=3.10.0,<3.14.0
   - tqdm
   - typing-extensions
   - zlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 requires = [
     "setuptools>=61",
     "wheel",
-    "numpy==2"
+    "numpy>=2.1"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -382,14 +382,14 @@ if __name__ == "__main__":
     setup(
         author="Deep Genomics",
         author_email="info@deepgenomics.com",
-        python_requires=">=3.9, <4",
+        python_requires=">=3.10, <4",
         classifiers=[
             "Development Status :: 5 - Production/Stable",
             "License :: OSI Approved :: Apache Software License",
-            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
         ],
         description="GenomeKit is a Python library for fast and easy access to genomic resources such as sequence, data tracks, and annotations.",
         long_description=(Path(__file__).parent / "README.md").read_text(),


### PR DESCRIPTION
override numpy pin to 2.x for Python 3.13 compat

- tested (in a dummy branch) that build-wheels also works
- read py313 release notes to look for potential memory mgmt bugs, nothing found

fixes #102