### PR TITLE
chore: add 4 rat annos

### DIFF
--- a/data-src/rn7/Ensembl/mRatBN7.2.113/fetch.sh
+++ b/data-src/rn7/Ensembl/mRatBN7.2.113/fetch.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+wget -O mRatBN7.2.113.gff3.gz ftp://ftp.ensembl.org/pub/release-113/gff3/rattus_norvegicus/Rattus_norvegicus.mRatBN7.2.113.gff3.gz

--- a/data-src/rn7/NCBI/rn7.RS_2023_06/fetch.sh
+++ b/data-src/rn7/NCBI/rn7.RS_2023_06/fetch.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+wget -O rn7.RS_2023_06.gff3.gz https://ftp.ncbi.nlm.nih.gov/genomes/all/annotation_releases/10116/GCF_015227675.2-RS_2023_06/GCF_015227675.2_mRatBN7.2_genomic.gff.gz

--- a/data-src/rn7/assembly/fetch.sh
+++ b/data-src/rn7/assembly/fetch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+wget https://hgdownload.soe.ucsc.edu/goldenPath/rn7/bigZips/rn7.2bit
+wget https://hgdownload.soe.ucsc.edu/goldenPath/rn7/bigZips/rn7.chrom.sizes
+wget https://hgdownload.soe.ucsc.edu/goldenPath/rn7/bigZips/rn7.chromAlias.txt

--- a/data-src/rn8/Ensembl/GRCr8.115/fetch.sh
+++ b/data-src/rn8/Ensembl/GRCr8.115/fetch.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+wget -O GRCr8.115.gff3.gz ftp://ftp.ensembl.org/pub/release-115/gff3/rattus_norvegicus/Rattus_norvegicus.GRCr8.115.gff3.gz
+
+# MT appears in the gff3 but not in the GRCr8 assembly files.
+# Remove all MT features
+# Using a literal tab character to support different versions of zgrep
+tmpfile=$(mktemp)
+zgrep -v "^MT	" GRCr8.115.gff3.gz | gzip > $tmpfile
+mv $tmpfile GRCr8.115.gff3.gz

--- a/data-src/rn8/NCBI/rn8.RS_2024_02/fetch.sh
+++ b/data-src/rn8/NCBI/rn8.RS_2024_02/fetch.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+wget -O rn8.RS_2024_02.gff3.gz https://ftp.ncbi.nlm.nih.gov/genomes/all/annotation_releases/10116/GCF_036323735.1-RS_2024_02/GCF_036323735.1_GRCr8_genomic.gff.gz

--- a/data-src/rn8/assembly/fetch.sh
+++ b/data-src/rn8/assembly/fetch.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# See https://www.ncbi.nlm.nih.gov/datasets/genome/GCF_036323735.1/ for source.
+# UCSC does not yet provide a goldenPath/rn8 mirror, so pull from the assembly hub.
+
+wget https://hgdownload.soe.ucsc.edu/hubs/GCF/036/323/735/GCF_036323735.1/GCF_036323735.1.2bit
+wget https://hgdownload.soe.ucsc.edu/hubs/GCF/036/323/735/GCF_036323735.1/GCF_036323735.1.chrom.sizes.txt
+wget https://hgdownload.soe.ucsc.edu/hubs/GCF/036/323/735/GCF_036323735.1/GCF_036323735.1.chromAlias.txt
+
+mv GCF_036323735.1.2bit rn8.2bit
+mv GCF_036323735.1.chrom.sizes.txt rn8.chrom.sizes
+mv GCF_036323735.1.chromAlias.txt rn8.chromAlias.txt


### PR DESCRIPTION
rn7 assembly:
mRatBN7.2.113
rn7.RS_2023_06

rn8 assembly:
GRCr8.115
rn8.RS_2024_02

NOTES:
- GRCr8 doesn't have a ucsc name yet; chose "rn8 " for now (GK/ucsc convention)
- 7 NM_ transcripts labeled protein_coding but with no CDS (rn8 RefSeq): Their coding region spans two reading frames with a join that a single contiguous-CDS model can't represent
- 5 duplicate gene IDs in rn8 RefSeq — all multi-copy tRNAs
- ~10K genes with no transcripts in both RefSeq builds — pseudogene loci