### PR TITLE
feat: add gkdf deserialization options

### DIFF
--- a/genome_kit/__init__.py
+++ b/genome_kit/__init__.py
@@ -50,7 +50,7 @@ from .variant import Variant, VariantTable
 from .variant_genome import VariantGenome
 from .vcf_table import VCFTable, VCFVariant
 from . import serialize
-from .df import write_parquet, read_parquet
+from .df import write_parquet, read_parquet, deserialize_gk_object
 
 #########################################################################
 
@@ -71,6 +71,7 @@ __all__ = [
     "Cds",
     "CdsTable",
     "DataManager",
+    "deserialize_gk_object",
     "DisjointIntervalSequence",
     "Exon",
     "ExonTable",

--- a/genome_kit/df/__init__.py
+++ b/genome_kit/df/__init__.py
@@ -1,3 +1,3 @@
-from .serialization import read_parquet, write_parquet
+from .serialization import read_parquet, write_parquet, deserialize_gk_object
 
-__all__ = ["read_parquet", "write_parquet"]
+__all__ = ["read_parquet", "write_parquet", "deserialize_gk_object"]

--- a/genome_kit/df/gk_structs.py
+++ b/genome_kit/df/gk_structs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
 from genome_kit._optional import require_polars
@@ -168,17 +169,20 @@ def get_structs() -> dict[GkDfType, pl.Struct]:
         GkDfType.VARIANT: VariantStruct,
     }
 
-_STRUCT_KEYS: dict[frozenset[str], GkDfType] | None = None
 
-def identify_struct(data: dict[str, Any]) -> GkDfType | None:
+@lru_cache(maxsize=1)
+def _get_struct_keys() -> dict[frozenset[str], GkDfType]:
+    return {
+        frozenset(f.name for f in struct.fields): t
+        for t, struct in get_structs().items()
+    }
+
+
+def identify_struct(data: dict[str, Any]) -> GkDfType:
     """Identify the GkDfType of a given dictionary based on its keys."""
-    global _STRUCT_KEYS
-    
-    if _STRUCT_KEYS is None:
-        _STRUCT_KEYS = {
-            frozenset(f.name for f in struct.fields): t
-            for t, struct in get_structs().items()
-        }
+    gkdf_type = _get_struct_keys().get(frozenset(data.keys()), None)
 
-    return _STRUCT_KEYS.get(frozenset(data.keys()), None)
+    if gkdf_type is None:
+        raise ValueError(f"Unrecognized struct keys: {data.keys()}")
 
+    return gkdf_type

--- a/genome_kit/df/gk_structs.py
+++ b/genome_kit/df/gk_structs.py
@@ -180,9 +180,4 @@ def _get_struct_keys() -> dict[frozenset[str], GkDfType]:
 
 def identify_struct(data: dict[str, Any]) -> GkDfType:
     """Identify the GkDfType of a given dictionary based on its keys."""
-    gkdf_type = _get_struct_keys().get(frozenset(data.keys()), None)
-
-    if gkdf_type is None:
-        raise ValueError(f"Unrecognized struct keys: {data.keys()}")
-
-    return gkdf_type
+    return _get_struct_keys()[frozenset(data.keys())]

--- a/genome_kit/df/gk_structs.py
+++ b/genome_kit/df/gk_structs.py
@@ -168,15 +168,17 @@ def get_structs() -> dict[GkDfType, pl.Struct]:
         GkDfType.VARIANT: VariantStruct,
     }
 
-_STRUCT_KEYS: dict[frozenset[str], GkDfType] = {
-    frozenset(f.name for f in struct.fields): t
-    for t, struct in get_structs().items()
-}
+_STRUCT_KEYS: dict[frozenset[str], GkDfType] | None = None
 
 def identify_struct(data: dict[str, Any]) -> GkDfType | None:
     """Identify the GkDfType of a given dictionary based on its keys."""
+    global _STRUCT_KEYS
+    
+    if _STRUCT_KEYS is None:
+        _STRUCT_KEYS = {
+            frozenset(f.name for f in struct.fields): t
+            for t, struct in get_structs().items()
+        }
 
-    data_keys = frozenset(data.keys())
-
-    return _STRUCT_KEYS.get(data_keys, None)
+    return _STRUCT_KEYS.get(frozenset(data.keys()), None)
 

--- a/genome_kit/df/gk_structs.py
+++ b/genome_kit/df/gk_structs.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from genome_kit._optional import require_polars
 
@@ -167,3 +167,16 @@ def get_structs() -> dict[GkDfType, pl.Struct]:
         GkDfType.UTR: UtrStruct,
         GkDfType.VARIANT: VariantStruct,
     }
+
+_STRUCT_KEYS: dict[frozenset[str], GkDfType] = {
+    frozenset(f.name for f in struct.fields): t
+    for t, struct in get_structs().items()
+}
+
+def identify_struct(data: dict[str, Any]) -> GkDfType | None:
+    """Identify the GkDfType of a given dictionary based on its keys."""
+
+    data_keys = frozenset(data.keys())
+
+    return _STRUCT_KEYS.get(data_keys, None)
+

--- a/genome_kit/df/serialization.py
+++ b/genome_kit/df/serialization.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 import genome_kit as gk
 from genome_kit._optional import require_polars
 
-from .gk_structs import CURRENT_VERSION, CellType, ColumnInfo, GkDfType, GkDfVersion
+from .gk_structs import CURRENT_VERSION, CellType, ColumnInfo, GkDfType, GkDfVersion, identify_struct
 from .registry import GK_TO_GKDF_TYPE, get_registry
 
 
@@ -382,7 +382,9 @@ def write_parquet(
     df.sink_parquet(path, metadata=metadata)
 
 
-def read_parquet(path: str | Path, lazy: bool = False) -> pl.DataFrame | pl.LazyFrame:
+def read_parquet(
+    path: str | Path, lazy: bool = False, deserialize_gk_objects: bool = True
+) -> pl.DataFrame | pl.LazyFrame:
     """Deserialize a Parquet file containing GenomeKit objects into a Polars DataFrame or LazyFrame.
 
     Args:
@@ -401,11 +403,40 @@ def read_parquet(path: str | Path, lazy: bool = False) -> pl.DataFrame | pl.Lazy
 
     lf = pl.scan_parquet(path)
 
-    # collect unique genome strings in the file and initialize, prevents race conditions
-    # on opening dganno files.
-    # genomes returned in dummy variable to keep weak reference alive for deserialization
-    _ = _init_gk_annotations(lf, target_cols)
+    if deserialize_gk_objects:
+        # collect unique genome strings in the file and initialize, prevents race conditions
+        # on opening dganno files.
+        # genomes returned in dummy variable to keep weak reference alive for deserialization
+        _ = _init_gk_annotations(lf, target_cols)
 
-    lf = _deserialize_gk_cols(lf, target_cols)
+        lf = _deserialize_gk_cols(lf, target_cols)
 
     return lf if lazy else lf.collect()
+
+
+def deserialize_gk_object(data: dict[str, Any]) -> Any:
+    """Deserialize a serialized GenomeKit object (dictionary) into a GenomeKit object. 
+
+    Intended for use with a dict representation of a single GenomeKit object created
+    from GenomeKit.write_parquet
+
+    Args:
+        data: A dictionary representation of a serialized GenomeKit object
+
+    Returns:
+        A deserialized GenomeKit object.
+    """
+    gkdf_type = identify_struct(data)
+    if gkdf_type is None:
+        raise ValueError(
+            "Unable to identify GenomeKit object type from dictionary keys. "
+            "Please ensure the dictionary is a valid serialized GenomeKit object."
+        )
+
+    registry = get_registry()
+    deserializer = registry[CURRENT_VERSION][gkdf_type].deserializer
+
+    pl = require_polars()
+    # deserializer takes in a polars Series
+    s = pl.Series(values=[data], dtype=pl.Object)
+    return deserializer(s)[0]

--- a/genome_kit/df/serialization.py
+++ b/genome_kit/df/serialization.py
@@ -463,7 +463,7 @@ def deserialize_gk_object(data: dict[str, Any]) -> Any:
         
     Returns:
         The deserialized GenomeKit object.
-    """
+    """ 
     # deserializer identified by gkdf version and gkdf type
     gkdf_type = identify_struct(data)
     version = data["schema_version"]

--- a/genome_kit/df/serialization.py
+++ b/genome_kit/df/serialization.py
@@ -452,4 +452,26 @@ def read_parquet(path: str | Path, astype: type[DF] | None = None, deserialize_g
     return _convert_to_output_format(lf, astype or pl.DataFrame)
 
 
+def deserialize_gk_object(data: dict[str, Any]) -> Any:
+    """Deserialize a serialized GenomeKit object from a dictionary representation.
+    
+    Intended for use with a dict representation of a single GenomeKit object 
+    created from GenomeKit.write_parquet()
+    
+    Args:
+        data: A dictionary representation of a serialized GenomeKit object.
+        
+    Returns:
+        The deserialized GenomeKit object.
+    """
+    # deserializer identified by gkdf version and gkdf type
+    gkdf_type = identify_struct(data)
+    version = data["schema_version"]
+
+    registry = get_registry()
+    deserializer = registry[version][gkdf_type].deserializer
+    pl = require_polars()
+    s = pl.Series(values=[data], dtype=pl.Object)
+
+    return deserializer(s).item()
 

--- a/genome_kit/df/serialization.py
+++ b/genome_kit/df/serialization.py
@@ -390,6 +390,8 @@ def read_parquet(
     Args:
         path: The file path to read the Parquet file from.
         lazy: If True, return a LazyFrame. Otherwise, return a DataFrame.
+        deserialize_gk_objects: If True, deserialize all GenomeKit objects in the 
+            DataFrame. If False, the serialized structs will be returned as is.
 
     Returns:
         A Polars DataFrame or LazyFrame with deserialized GenomeKit objects.

--- a/genome_kit/df/serialization.py
+++ b/genome_kit/df/serialization.py
@@ -433,8 +433,9 @@ def deserialize_gk_object(data: dict[str, Any]) -> Any:
             "Please ensure the dictionary is a valid serialized GenomeKit object."
         )
 
+    version = data['schema_version']
     registry = get_registry()
-    deserializer = registry[CURRENT_VERSION][gkdf_type].deserializer
+    deserializer = registry[version][gkdf_type].deserializer
 
     pl = require_polars()
     # deserializer takes in a polars Series

--- a/tests/test_gkdf.py
+++ b/tests/test_gkdf.py
@@ -5,7 +5,7 @@ import unittest
 from pathlib import Path
 
 from genome_kit import Genome, Interval, Variant
-from genome_kit.df import read_parquet, write_parquet
+from genome_kit.df import deserialize_gk_object, read_parquet, write_parquet
 from genome_kit.df.gk_structs import CURRENT_VERSION
 
 HAS_POLARS = importlib.util.find_spec("polars") is not None
@@ -314,6 +314,62 @@ class TestGkdfRoundTrip(unittest.TestCase):
         )
         with self.assertRaises(ValueError):
             read_parquet(path, lazy=False)
+
+    @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
+    def test_deserialize_gk_objects_false(self):
+        g = Genome("gencode.v41.mini")
+        gene = g.genes[0]
+        df = pl.DataFrame({"gene": [gene]})
+
+        path = self.tmp_dir_path / "deserialize_false.parquet"
+        write_parquet(df, path)
+
+        re_df = read_parquet(path, lazy=False, deserialize_gk_objects=False)
+
+        # column should contain raw struct, not a deserialized GenomeKit object
+        cell = re_df["gene"].item()
+        self.assertIsInstance(cell, dict)
+        self.assertIn("gene_table_index", cell)
+        self.assertIn("anno", cell)
+
+    @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
+    def test_deserialize_lazy(self):
+        g = Genome("gencode.v41.mini")
+        gene = g.genes[0]
+        df = pl.DataFrame({"gene": [gene]})
+
+        path = self.tmp_dir_path / "deserialize_lazy.parquet"
+        write_parquet(df, path)
+
+        re_df = read_parquet(path, lazy=True)
+        self.assertIsInstance(re_df, pl.LazyFrame)
+
+    @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
+    def test_deserialize_gk_object_roundtrip(self):
+        g = Genome("gencode.v41.mini")
+        gene = g.genes[0]
+        df = pl.DataFrame({"gene": [gene]})
+
+        path = self.tmp_dir_path / "deserialize_single.parquet"
+        write_parquet(df, path)
+
+        re_df = read_parquet(path, lazy=False, deserialize_gk_objects=False)
+        data = re_df["gene"].item()
+
+        obj = deserialize_gk_object(data)
+        self.assertEqual(obj, gene)
+
+    @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
+    def test_deserialize_gk_object_invalid_dict(self):
+        # test that error raised when dict keys don't match any GkDfType
+        with self.assertRaises(ValueError):
+            deserialize_gk_object({"not_a_valid": "key", "foo": "bar"})
+
+    @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
+    def test_deserialize_gk_object_empty_dict(self):
+        # test that error raised when dict is empty
+        with self.assertRaises(ValueError):
+            deserialize_gk_object({})
 
 
 if __name__ == "__main__":

--- a/tests/test_gkdf.py
+++ b/tests/test_gkdf.py
@@ -382,25 +382,13 @@ class TestGkdfRoundTrip(unittest.TestCase):
         path = self.tmp_dir_path / "deserialize_false.parquet"
         write_parquet(df, path)
 
-        re_df = read_parquet(path, lazy=False, deserialize_gk_objects=False)
+        re_df = read_parquet(path, deserialize_gk_objects=False)
 
         # column should contain raw struct, not a deserialized GenomeKit object
         cell = re_df["gene"].item()
         self.assertIsInstance(cell, dict)
         self.assertIn("gene_table_index", cell)
         self.assertIn("anno", cell)
-
-    @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
-    def test_deserialize_lazy(self):
-        g = Genome("gencode.v41.mini")
-        gene = g.genes[0]
-        df = pl.DataFrame({"gene": [gene]})
-
-        path = self.tmp_dir_path / "deserialize_lazy.parquet"
-        write_parquet(df, path)
-
-        re_df = read_parquet(path, lazy=True)
-        self.assertIsInstance(re_df, pl.LazyFrame)
 
     @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
     def test_deserialize_gk_object_roundtrip(self):
@@ -411,7 +399,7 @@ class TestGkdfRoundTrip(unittest.TestCase):
         path = self.tmp_dir_path / "deserialize_single.parquet"
         write_parquet(df, path)
 
-        re_df = read_parquet(path, lazy=False, deserialize_gk_objects=False)
+        re_df = read_parquet(path, deserialize_gk_objects=False)
         data = re_df["gene"].item()
 
         obj = deserialize_gk_object(data)
@@ -425,7 +413,6 @@ class TestGkdfRoundTrip(unittest.TestCase):
 
     @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
     def test_deserialize_gk_object_empty_dict(self):
-        # test that error raised when dict is empty
         with self.assertRaises(ValueError):
             deserialize_gk_object({})
 

--- a/tests/test_gkdf.py
+++ b/tests/test_gkdf.py
@@ -237,7 +237,7 @@ class TestGkdfRoundTrip(unittest.TestCase):
 
         path = self.tmp_dir_path / "multiple_types.parquet"
         write_parquet(df, path)
-        re_df = read_parquet(path)
+        re_df = read_parquet(path, deserialize_gk_objects=True)
         self.assertEqual(re_df["interval"].item(), df["interval"].item())
         self.assertEqual(re_df["transcript"].item(), df["transcript"].item())
         self.assertEqual(re_df["gene"].item(), df["gene"].item())
@@ -408,13 +408,9 @@ class TestGkdfRoundTrip(unittest.TestCase):
     @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
     def test_deserialize_gk_object_invalid_dict(self):
         # test that error raised when dict keys don't match any GkDfType
-        with self.assertRaises(ValueError):
+        with self.assertRaises(KeyError):
             deserialize_gk_object({"not_a_valid": "key", "foo": "bar"})
 
-    @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df tests")
-    def test_deserialize_gk_object_empty_dict(self):
-        with self.assertRaises(ValueError):
-            deserialize_gk_object({})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a flag for optional deserialization of gk objects. Also adds and exposes a function to deserialize a single gk object. 

Both additions are used in some workflows where large parquet files are read without deserializing gk objects, then pulling out a single cell and deserializing that object. 