### PR TITLE
fix: remove python roundtrip in list ser/de

### DIFF
--- a/docs-src/df.rst
+++ b/docs-src/df.rst
@@ -40,6 +40,9 @@ The serialization and deserialization entry points are :py:func:`~genome_kit.df.
     ...
     restored_df = gk.read_parquet("genes.parquet")
 
+.. note::
+    In this subpackage, lists of GenomeKit objects are supported, (e.g. ``List[Gene]``) while nested lists of GenomeKit objects are not supported (e.g. ``List[List[Transcript]]``). 
+    Nested lists of standard Python objects (e.g. ``List[List[int]]``) are supported.
 
 .. note::
     

--- a/genome_kit/df/serialization.py
+++ b/genome_kit/df/serialization.py
@@ -104,8 +104,8 @@ def _detect_gk_cols(
 
     return target_cols
 
-def _explode_list(flattened: list[Any], orig_lengths: list[int]) -> list[list | None]:
-    """Explode a flattened list back into its original list structure."""
+def _unflatten_list(flattened: list[Any], orig_lengths: list[int]) -> list[list | None]:
+    """Restore a flattened list back into its original list structure."""
     out = []
     pos = 0
     for length in orig_lengths:
@@ -123,8 +123,8 @@ def _list_serializer(
     """Convert a serializer to accept a series of lists of objects.
     
     Default serializers accept a series of single objects. Flattens pl.Series of 
-    lists to a pl.Series of single objects, applies serialization, then explodes
-    back to original list structure.
+    lists to a pl.Series of single objects, applies serialization, then restores
+    back the original list structure.
     """
     pl = require_polars()
 
@@ -132,7 +132,7 @@ def _list_serializer(
     def _serialize_list(s: pl.Series) -> pl.Series:
         flattened = []
         orig_lengths = []
-        # keep track of original lengths to explode back to original list structure
+        # keep track of original lengths to restore original list structure
         for row in s:
             if row is None:
                 orig_lengths.append(0)
@@ -142,7 +142,7 @@ def _list_serializer(
 
         serialized = serializer(pl.Series(values=flattened)).to_list()
 
-        return pl.Series(name=s.name, values=_explode_list(serialized, orig_lengths), dtype=return_dtype)
+        return pl.Series(name=s.name, values=_unflatten_list(serialized, orig_lengths), dtype=return_dtype)
 
     return _serialize_list
 
@@ -258,10 +258,10 @@ def _list_deserializer(
 
     def _deserialize_list(s: pl.Series) -> pl.Series:
         lengths = s.list.len().to_list()
-        flat = s.explode(empty_as_null=False)
-        deserialized = deserializer(flat).to_list()
+        exploded = s.explode(empty_as_null=False)
+        deserialized = deserializer(exploded).to_list()
 
-        return pl.Series(name=s.name, values=_explode_list(deserialized, lengths), dtype=pl.Object)
+        return pl.Series(name=s.name, values=_unflatten_list(deserialized, lengths), dtype=pl.Object)
 
     return _deserialize_list
 

--- a/genome_kit/df/serialization.py
+++ b/genome_kit/df/serialization.py
@@ -104,26 +104,45 @@ def _detect_gk_cols(
 
     return target_cols
 
+def _explode_list(flattened: list[Any], orig_lengths: list[int]) -> list[list | None]:
+    """Explode a flattened list back into its original list structure."""
+    out = []
+    pos = 0
+    for length in orig_lengths:
+        if length == 0:
+            out.append(None)
+        else:
+            out.append(flattened[pos : pos + length])
+            pos += length
+    return out
+
 
 def _list_serializer(
     serializer: Callable[[pl.Series], pl.Series], return_dtype: Any
 ) -> Callable[[pl.Series], pl.Series]:
     """Convert a serializer to accept a series of lists of objects.
     
-    Default serializers accept a series of single objects.
+    Default serializers accept a series of single objects. Flattens pl.Series of 
+    lists to a pl.Series of single objects, applies serialization, then explodes
+    back to original list structure.
     """
-
     pl = require_polars()
 
+    # input `s` will be a column, where each cell is a list or None
     def _serialize_list(s: pl.Series) -> pl.Series:
-        return pl.Series(
-            name=s.name,
-            values=[
-                serializer(pl.Series(values=l)).to_list() if l is not None else None
-                for l in s
-            ],
-            dtype=return_dtype,
-        )
+        flattened = []
+        orig_lengths = []
+        # keep track of original lengths to explode back to original list structure
+        for row in s:
+            if row is None:
+                orig_lengths.append(0)
+            else:
+                flattened.extend(row)
+                orig_lengths.append(len(row))
+
+        serialized = serializer(pl.Series(values=flattened)).to_list()
+
+        return pl.Series(name=s.name, values=_explode_list(serialized, orig_lengths), dtype=return_dtype)
 
     return _serialize_list
 
@@ -158,7 +177,7 @@ def _init_gk_annotations(
         if target_cols[c]["cell_type"] == CellType.SCALAR:
             genomes_exprs.append(pl.col(c).struct.field(genome_field))
         else:
-            genomes_list_exprs.append(pl.col(c).explode().struct.field(genome_field))
+            genomes_list_exprs.append(pl.col(c).explode(empty_as_null=False).struct.field(genome_field))
 
     # expressions to extract genome_str must be run separately since exploded lists
     # may have more rows than the original dataframe
@@ -168,7 +187,7 @@ def _init_gk_annotations(
         plans.append(
             lf.select(
                 pl.concat_list(genomes_exprs)
-                .explode()
+                .explode(empty_as_null=False)
                 .drop_nulls()
                 .unique()
                 .alias("genome_str")
@@ -179,7 +198,7 @@ def _init_gk_annotations(
         plans.append(
             lf.select(
                 pl.concat(genomes_list_exprs)
-                .explode()
+                .explode(empty_as_null=False)
                 .drop_nulls()
                 .unique()
                 .alias("genome_str")
@@ -238,14 +257,11 @@ def _list_deserializer(
     pl = require_polars()
 
     def _deserialize_list(s: pl.Series) -> pl.Series:
-        return pl.Series(
-            name=s.name,
-            values=[
-                deserializer(pl.Series(values=l)).to_list() if l is not None else None
-                for l in s
-            ],
-            dtype=pl.Object,
-        )
+        lengths = s.list.len().to_list()
+        flat = s.explode(empty_as_null=False)
+        deserialized = deserializer(flat).to_list()
+
+        return pl.Series(name=s.name, values=_explode_list(deserialized, lengths), dtype=pl.Object)
 
     return _deserialize_list
 

--- a/genome_kit/df/serialization.py
+++ b/genome_kit/df/serialization.py
@@ -109,6 +109,7 @@ def _unflatten_list(flattened: list[Any], orig_lengths: list[int]) -> list[list 
     out = []
     pos = 0
     for length in orig_lengths:
+        # null values stored as length 0
         if length == 0:
             out.append(None)
         else:
@@ -133,8 +134,8 @@ def _list_serializer(
         flattened = []
         orig_lengths = []
         # keep track of original lengths to restore original list structure
-        for row in s:
-            if row is None:
+        for row in s.to_list():
+            if row is None: # when converting to list, pl.Null becomes None
                 orig_lengths.append(0)
             else:
                 flattened.extend(row)
@@ -257,8 +258,11 @@ def _list_deserializer(
     pl = require_polars()
 
     def _deserialize_list(s: pl.Series) -> pl.Series:
-        lengths = s.list.len().to_list()
-        exploded = s.explode(empty_as_null=False)
+        # fill_null with 0 so None values are treated as empty lists
+        lengths = s.list.len().fill_null(0).to_list()
+        # don't keep nulls or empty lists when exploding
+        # consistent with empty list and nulls as length 0 in _unflatten_list
+        exploded = s.explode(empty_as_null=False, keep_nulls=False)
         deserialized = deserializer(exploded).to_list()
 
         return pl.Series(name=s.name, values=_unflatten_list(deserialized, lengths), dtype=pl.Object)

--- a/tests/test_gkdf.py
+++ b/tests/test_gkdf.py
@@ -209,13 +209,17 @@ class TestGkdfRoundTrip(unittest.TestCase):
         transcripts = list(g.transcripts)[:10]
         transcripts[:3] = [None] * 3
         df = pl.DataFrame(
-            {"transcripts": [transcripts]}, schema={"transcripts": pl.Object}
+            {"transcripts": [transcripts, [], [None], None]}, schema={"transcripts": pl.Object}
         )
 
         path = self.tmp_dir_path / "list_of_transcripts_with_null.parquet"
         write_parquet(df, path)
         re_df = read_parquet(path)
-        self.assertEqual(re_df.item(), df.item())
+        self.assertEqual(re_df["transcripts"][0], df["transcripts"][0])
+        # empty list becomes none on deserialization
+        self.assertEqual(re_df["transcripts"][1], None)
+        self.assertEqual(re_df["transcripts"][2], df["transcripts"][2])
+        self.assertEqual(re_df["transcripts"][3], df["transcripts"][3])
 
     @unittest.skipUnless(HAS_POLARS, "Polars is required for this genome_kit.df test")
     def test_multiple_types(self):


### PR DESCRIPTION
Previous list serialization/deserialization paths treated used each cell as a separate call to the appropriate function. Since the  serde functions took polars series as input, this meant every cell was converted from `list -> pl.Series -> list`. The time taken for this conversion is mostly inconsequential, but adds up over larger dataframes. 

The new implementation flattens a column (of list of GK objects/structs) into a single list, converts that into a `pl.Series`, and runs that through the appropriate function before reconstructing the correct list lengths. 

Empirically, this speeds up the serde paths by around 2-3 times:

```
# 1,000,000 row dataframe with lists (len between 2-8) of random GK Intervals
DataFrame creation time: 2.21293s
old serialization time: 124.13172s
newer serialization time: 62.46663s
---------------------------------
old deserialization time: 33.74061s
newer deserialization time: 13.30726s
```




Also makes polars options explicit when exploding lists of objects and correct `None` object serde.