### PR TITLE
feat: add IntervalData

### DIFF
--- a/docs-src/diseq.rst
+++ b/docs-src/diseq.rst
@@ -805,8 +805,9 @@ travel between them.
 
 :py:meth:`~genome_kit.diseq.DisjointIntervalSequence.lower` projects the segment back to
 genomic space. :py:meth:`~genome_kit.diseq.DisjointIntervalSequence.lift_interval`
-projects a genomic interval into the DIS's index space and clips it
-against the segment. They are conceptual inverses, but each has to deal
+projects a genomic interval into the DIS's index space, requiring it to map
+cleanly onto the segment (or clipping it against the segment when
+``intersect_on_lift=True``). They are conceptual inverses, but each has to deal
 with a structural mismatch — gaps in genomic space have no representation
 in DIS space, and contiguous DIS indices may correspond to two
 non-adjacent genomic regions — so neither is a clean bijection.
@@ -857,16 +858,22 @@ lift_interval
 
 :py:meth:`~genome_kit.diseq.DisjointIntervalSequence.lift_interval` is the inverse: it takes
 a genomic :py:class:`~genome_kit.Interval` and returns a new DIS whose segment is
-the intersection of that interval with this DIS's segment, expressed
-in the DIS coordinate space. The input must share the same chromosome, reference
-genome, and effective strand as the DIS.
+that interval expressed in the DIS coordinate space. The input must share the
+same chromosome, reference genome, and effective strand as the DIS.
 
-The lift is well-defined even when the input straddles gaps between coord
-intervals: positions inside a gap collapse to the boundary index of the
-adjacent coord interval, and positions outside the coord space extrapolate
-linearly. The result is then clipped against the DIS's segment, so a
-genomic interval that overlaps coord space but falls entirely outside the
-segment returns ``None``
+By default (``intersect_on_lift=False``) the input must map cleanly onto the
+DIS's segment — that is, it must be fully contained within the segment's bases.
+If it is not (it straddles the segment edge, falls in a coord-interval gap, or
+spans the gap between two coord intervals), :py:meth:`lift_interval` raises a
+``ValueError``.
+
+Pass ``intersect_on_lift=True`` to instead clip the lifted interval against the
+DIS's segment. This lift is well-defined even when the input straddles gaps
+between coord intervals: positions inside a gap collapse to the boundary index
+of the adjacent coord interval, and positions outside the coord space
+extrapolate linearly. The clipped result is then intersected with the segment,
+so a genomic interval that overlaps coord space but falls entirely outside the
+segment returns ``None``.
 
 .. code-block:: python
 
@@ -875,15 +882,22 @@ segment returns ``None``
     ...      Interval("chr1", "+", 300, 400, "hg38")],
     ...     start=0, end=200,
     ... )
+    >>> # Fully contained in the segment: lifts cleanly with the default.
     >>> lifted = dis.lift_interval(Interval("chr1", "+", 320, 360, "hg38"))
     >>> lifted.start, lifted.end
     (120, 160)
 
-    >>> # Falls in a coord-interval gap with no overlap of any coord interval
-    >>> dis.lift_interval(Interval("chr1", "+", 250, 260, "hg38")) is None
+    >>> # Not contained in the segment: raises unless intersect_on_lift=True.
+    >>> dis.lift_interval(Interval("chr1", "+", 250, 260, "hg38"))
+    Traceback (most recent call last):
+        ...
+    ValueError: ... Set intersect_on_lift=True to allow lifting and intersecting with the DIS segment.
+
+    >>> # Falls in a coord-interval gap with no overlap of any coord interval.
+    >>> dis.lift_interval(Interval("chr1", "+", 250, 260, "hg38"), intersect_on_lift=True) is None
     True
 
-    >>> lifted2 = dis.lift_interval(Interval("chr1", "+", 150, 450, "hg38"))
+    >>> lifted2 = dis.lift_interval(Interval("chr1", "+", 150, 450, "hg38"), intersect_on_lift=True)
     >>> lifted2.start, lifted2.end
     (50, 200)   # clipped to the DIS segment
 

--- a/docs-src/diseq.rst
+++ b/docs-src/diseq.rst
@@ -470,8 +470,9 @@ segment layer, not the coordinate intervals.
 Shifting and Expanding
 ======================
 
-Both :py:meth:`~genome_kit.diseq.DisjointIntervalSequence.shift` and
-:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.expand` return a **new** DIS with
+:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.shift`,
+:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.expand`, and
+:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.cut` all return a **new** DIS with
 modified segment indices. The coordinate space is always unchanged.
 
 shift
@@ -586,6 +587,25 @@ Negative values contract the segment::
 
     Contracting to exactly zero length is valid, but contracting past
     zero raises ``ValueError``.
+
+cut
+~~~
+
+:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.cut` sets the segment directly from
+absolute coordinate-space indices, rather than moving or growing the existing
+segment. ``start`` and ``end`` use the same convention as the
+:py:attr:`~genome_kit.diseq.DisjointIntervalSequence.start` and
+:py:attr:`~genome_kit.diseq.DisjointIntervalSequence.end` attributes.
+
+.. code-block:: python
+
+    >>> dis.start, dis.end
+    (30, 150)
+    >>> cut = dis.cut(40, 120)
+    >>> cut.start, cut.end
+    (40, 120)
+    >>> cut.coordinate_intervals == dis.coordinate_intervals
+    True
 
 expand_coord
 ~~~~~~~~~~~~

--- a/docs-src/diseq.rst
+++ b/docs-src/diseq.rst
@@ -25,12 +25,12 @@ is conceptually distinct in several ways:
   regardless of genomic strand. This contrasts with
   :py:class:`~genome_kit.Interval`, where ``start < end`` always holds in
   genomic coordinates, so on the ``-`` strand ``start`` is the 3' end.
-- **Same-strand / opposite-strand semantics.** Because a DIS models spliced
+- **On-coordinate / off-coordinate semantics.** Because a DIS models spliced
   RNA rather than raw DNA, the concept of ``+``/``-`` strand is replaced by
-  ``on_coordinate_strand`` (same strand as the transcript) versus opposite
-  strand. The underlying genomic strand is accessible via ``coord_strand``,
-  but segments within the DIS are described relative to the coordinate
-  space rather than in absolute genomic terms.
+  ``on_coordinate_strand``: a segment is either on the coordinate strand (the
+  strand of the coordinate intervals) or off it. The underlying genomic strand
+  is accessible via ``coord_strand``, but segments within the DIS are described
+  relative to the coordinate space rather than in absolute genomic terms.
 
 Overview
 ========
@@ -114,7 +114,7 @@ and an end index of 7
     :py:class:`~genome_kit.Interval` where ranges are half-open
     (the end index is exclusive).
 
-A DIS can also represent a segment on the strand opposite the coordinate space.
+A DIS can also represent a segment off the coordinate strand.
 This is useful for modeling the complementary sequence or a binding partner.
 
 Starting from the coordinate space defined above::
@@ -124,7 +124,7 @@ Starting from the coordinate space defined above::
                         |  |<----->|   |<->|   |<->|  |
                         5'   Exon1     Exon2   Exon3  3'
 
-The opposite strand shares the same DIS coordinate indices::
+A segment off the coordinate strand shares the same DIS coordinate indices::
 
                         5'      Positive strand          3'
     DIS Coordinates:    |  0   1   2   3   4   5   6   7 |
@@ -134,10 +134,10 @@ The opposite strand shares the same DIS coordinate indices::
     DIS Coordinates:    |  0   1   2   3   4   5   6   7 |
                         3'      Negative Strand          5'
 
-The DIS coordinate indices are identical on both strands. To obtain the complement
-of a given segment, the same start and end indices apply; only the
-``on_coordinate_strand`` flag changes. The following shows the full-length segment
-on the opposite strand::
+The DIS coordinate indices are identical whether or not the segment is on the
+coordinate strand. To obtain the complement of a given segment, the same start
+and end indices apply; only the ``on_coordinate_strand`` flag changes. The
+following shows the full-length segment off the coordinate strand::
 
                         5'      Coordinate Strand        3'
     DIS Coordinates:    |  0   1   2   3   4   5   6   7 |
@@ -145,14 +145,14 @@ on the opposite strand::
     -----------------------------------------------------
     DNA Sequence (-):      T   A   C   G   T   C   G
     DIS Coordinates:       0   1   2   3   4   5   6   7
-                                  Opposite Strand
+                               Off Coordinate Strand
                            |<--------------------->|
                           end3       Segment       end5
     Start Index:     0
     End Index:       7
     On Coordinate Strand: False
 
-The ``on_coordinate_strand`` flag distinguishes same-strand from opposite-strand
+The ``on_coordinate_strand`` flag distinguishes on-coordinate from off-coordinate
 segments, since the start and end indices alone do not encode strand information
 
 .. code-block:: python
@@ -235,7 +235,8 @@ A full-length segment on the coordinate strand::
 
 Despite creating the DIS from the negative strand, the full-length segment on the
 coordinate strand is identical to the + strand example. When working with DIS
-objects, strand is expressed only as "same strand" or "opposite strand"
+objects, strand is expressed only as "on the coordinate strand" or "off the
+coordinate strand"
 
 .. code-block:: python
 
@@ -246,7 +247,7 @@ objects, strand is expressed only as "same strand" or "opposite strand"
     >>> dis_neg.on_coordinate_strand
     True
 
-The same coordinate space with an opposite-strand segment::
+The same coordinate space with an off-coordinate-strand segment::
 
     DIS Coordinates:       0   1   2   3   4   5   6   7
     DNA Sequence (-):      T   G   A   C   C   T   G
@@ -390,7 +391,7 @@ When ``on_coordinate_strand`` is ``True``, ``end5_index`` equals ``start`` and
     -----------------------------------------------------
     DNA Sequence:          A   C   T   G   G   A   C
     DIS Coordinates:       0   1   2   3   4   5   6   7
-                                  Opposite Strand
+                               Off Coordinate Strand
 
 .. code-block:: python
 
@@ -411,7 +412,7 @@ When ``on_coordinate_strand`` is ``False``, the mapping reverses:
     DNA Sequence:          A   C   T   G   G   A   C
     DIS Coordinates:       0   1   2   3   4   5   6   7
                                        |<--------->|
-                                  Opposite Strand
+                               Off Coordinate Strand
 
 .. code-block:: python
 
@@ -440,7 +441,7 @@ Strand Methods
 
 A DIS segment can sit on either 'virtual' strand independently of the coordinate
 intervals. The ``on_coordinate_strand`` property indicates whether the
-segment is on the same strand as the coordinate intervals::
+segment is on the coordinate strand::
 
     On Coordinate Strand: True
     Start Index:     1
@@ -451,19 +452,19 @@ segment is on the same strand as the coordinate intervals::
     -----------------------------------------------------
     DNA Sequence (-):      T   A   G   G   C   T   G
     DIS Coordinates:       0   1   2   3   4   5   6   7
-                                  Opposite Strand
+                               Off Coordinate Strand
 
 .. code-block:: python
 
     >>> dis.on_coordinate_strand
     True
-    >>> dis.is_same_strand()
+    >>> dis.is_on_coordinate_strand()
     True
     >>> dis.is_positive_strand()
     True
 
-Strand methods (:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.is_same_strand`,
-:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.flip_strand`, etc.) only affect the
+Strand methods (:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.is_on_coordinate_strand`,
+:py:meth:`~genome_kit.diseq.DisjointIntervalSequence.as_opposite_strand`, etc.) only affect the
 segment layer, not the coordinate intervals.
 
 
@@ -493,7 +494,7 @@ On the coordinate strand, downstream means increasing indices::
                                    |<--------->|
                                   end5        end3
 
-On the opposite strand, "downstream" is the reverse direction in index
+Off the coordinate strand, "downstream" is the reverse direction in index
 space, so ``shift(1)`` moves the segment toward *lower* indices::
 
     Before shift(1) (on_coordinate_strand=False):
@@ -520,7 +521,7 @@ space, so ``shift(1)`` moves the segment toward *lower* indices::
     >>> dis.shift(-10).start, dis.shift(-10).end
     (20, 140)
 
-    >>> # On the opposite strand, downstream reverses in index space
+    >>> # Off the coordinate strand, downstream reverses in index space
     >>> opp = dis.as_opposite_strand()
     >>> opp.start, opp.end
     (30, 150)
@@ -862,8 +863,8 @@ extrapolated** from the nearest outer edge of the coord intervals. The
 returned intervals can therefore have negative starts or ends past the
 chromosome length — there is no clipping to chromosome boundaries.
 
-A segment on the opposite strand lowers to genomic intervals on the
-opposite strand, listed in *segment* 5'→3' order (which is the reverse of
+A segment off the coordinate strand lowers to genomic intervals on the
+off-coordinate strand, listed in *segment* 5'→3' order (which is the reverse of
 coord 5'→3' order)
 
 .. code-block:: python
@@ -932,8 +933,8 @@ reference, and the pieces are concatenated. This returns the spliced sequence
 of the transcript: the gaps between coord intervals are dropped so that introns
 (or other intervening regions) never appear in the output.
 
-The returned string already accounts for strand: if the segment is on the
-opposite strand, the segment's bases are returned, and the bases are
+The returned string already accounts for strand: if the segment is off the
+coordinate strand, the segment's bases are returned, and the bases are
 ordered 5'→3'
 
 .. code-block:: python
@@ -943,7 +944,7 @@ ordered 5'→3'
     'ACGTGGTTTCA'        # full spliced sequence, 5'→3'
 
     >>> opp = dis.as_opposite_strand()
-    >>> opp.dna()       # reverse complement, 5'→3' along the opposite strand
+    >>> opp.dna()       # reverse complement, 5'→3' along the off-coordinate strand
     'TGAAACCACGT'
 
 When the segment extends past the coord space — e.g. after

--- a/docs-src/index.rst
+++ b/docs-src/index.rst
@@ -71,6 +71,7 @@ Contents:
 
     quickstart
     diseq
+    interval_data
     anchors
     api
     genomes

--- a/docs-src/interval_data.rst
+++ b/docs-src/interval_data.rst
@@ -9,8 +9,8 @@ Overview
 
 An :py:class:`~genome_kit.IntervalData` is an object that associates a NumPy array with
 a genomic interval. Conceptually, it is similar to a
-:py:class:`~genome_kit.GenomeTrack`, but in-memory and scoped to a single
-interval-like object.
+:py:class:`~genome_kit.GenomeTrack`, but in-memory (doesn't require a file) and
+scoped to a single interval-like object.
 
 More specifically, an :py:class:`~genome_kit.IntervalData` binds three things:
 

--- a/docs-src/interval_data.rst
+++ b/docs-src/interval_data.rst
@@ -1,0 +1,311 @@
+.. _interval_data:
+
+-------------------------------
+Interval Data
+-------------------------------
+
+Overview
+========
+
+An :py:class:`~genome_kit.IntervalData` is an object that associates a NumPy array with
+a genomic interval. Conceptually, it is similar to a
+:py:class:`~genome_kit.GenomeTrack`, but in-memory and scoped to a single
+interval-like object.
+
+More specifically, an :py:class:`~genome_kit.IntervalData` binds three things:
+
+- ``interval`` — the backing coordinate object, either an
+  :py:class:`~genome_kit.Interval` or a
+  :py:class:`~genome_kit.DisjointIntervalSequence`.
+- ``data`` — an array whose aligned axis has the same length as ``interval``.
+- ``axis`` — which axis of ``data`` is aligned to ``interval`` (default ``0``).
+
+The data is assumed to be **unstranded and ordered 5'→3'** along the interval,
+much like a :ref:`track <tracks>`. Indexing then falls into two categories:
+
+- **Array indexing** (an integer, or a tuple that indexes the aligned axis with
+  an integer) acts directly on ``data`` and returns the raw array element.
+- **Splicing** (a ``slice``, an :py:class:`~genome_kit.Interval`, or a
+  :py:class:`~genome_kit.DisjointIntervalSequence`) slices *both* the interval
+  and the data, returning a new :py:class:`~genome_kit.IntervalData` whose
+  ``interval`` and ``data`` still line up. Splicing onto the opposite strand
+  reverses the data, so index 0 always corresponds to the 5' end of the result.
+
+.. code-block:: python
+
+    >>> import genome_kit as gk
+    >>> import numpy as np
+    >>> interval = gk.Interval("chr7", "+", 100000, 100500, "hg19")
+    >>> data = np.arange(len(interval))
+    >>> interval_data = gk.IntervalData(interval, data)
+    >>> len(interval_data)
+    500
+
+Construction
+============
+
+From a single Interval
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The most direct case is a contiguous genomic region. The aligned axis of ``data``
+must have the same length as the interval
+
+.. code-block:: python
+
+    >>> interval = gk.Interval("chr7", "+", 100000, 100500, "hg19")
+    >>> data = np.arange(len(interval))          # length 500, one value per base
+    >>> interval_data = gk.IntervalData(interval, data)
+
+:py:meth:`~genome_kit.IntervalData.from_interval` is an explicit alias for this
+case and behaves identically to the constructor.
+
+From a DisjointIntervalSequence
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the data describes a discontiguous region (e.g. a transcript's exons), back the
+:py:class:`~genome_kit.IntervalData` with a
+:py:class:`~genome_kit.DisjointIntervalSequence`. The aligned axis must match the
+DIS segment length (``len(dis)``), i.e. the length of the *spliced* sequence, not
+the genomic span
+
+.. code-block:: python
+
+    >>> from genome_kit.diseq import DisjointIntervalSequence
+    >>> dis = DisjointIntervalSequence.from_transcript(transcript)
+    >>> data = np.arange(len(dis))
+    >>> interval_data = gk.IntervalData.from_dis(dis, data)
+
+From a sequence of Intervals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:py:meth:`~genome_kit.IntervalData.from_intervals` builds the backing DIS for you
+from a set of non-overlapping intervals on the same chromosome, strand, and
+reference genome
+
+.. code-block:: python
+
+    >>> exons = [e.interval for e in transcript.exons]
+    >>> data = np.arange(sum(len(e) for e in exons))
+    >>> interval_data = gk.IntervalData.from_intervals(exons, data)
+
+This is equivalent to calling
+:py:meth:`~genome_kit.DisjointIntervalSequence.from_intervals` and then
+:py:meth:`~genome_kit.IntervalData.from_dis`.
+
+The aligned axis
+~~~~~~~~~~~~~~~~~
+
+Data is rarely one-dimensional. The ``axis`` argument tells
+:py:class:`~genome_kit.IntervalData` which axis is aligned to the interval
+
+.. code-block:: python
+
+    >>> interval = gk.Interval("chr7", "+", 100000, 100500, "hg19")
+    >>> data = np.zeros((5, len(interval), 10))   # length is on axis 1
+    >>> interval_data = gk.IntervalData(interval, data, axis=1)
+    >>> len(interval_data)
+    500
+
+If your aligned axis is not where you need it, use ``axis`` to point at it, or
+reorder the array up-front and leave ``axis`` at its default.
+
+Array Indexing
+==============
+
+Indexing that resolves to a concrete position on the aligned axis returns the
+underlying array data directly
+
+.. code-block:: python
+
+    >>> data = np.arange(30).reshape(3, 10)
+    >>> interval = gk.Interval("chr1", "+", 100, 103, "hg19")
+    >>> interval_data = gk.IntervalData(interval, data)
+    >>> interval_data[0]           # first position along the interval
+    array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+Iterating an :py:class:`~genome_kit.IntervalData` yields these per-position
+values in order, so ``[x for x in interval_data]`` walks the data 5'→3'.
+
+A tuple whose entry on the aligned axis is an integer likewise returns raw array
+data — the whole tuple is forwarded to the underlying array
+
+.. code-block:: python
+
+    >>> data = np.arange(30).reshape(5, 3, 2)
+    >>> interval = gk.Interval("chr1", "+", 100, 103, "hg19")
+    >>> interval_data = gk.IntervalData(interval, data, axis=1)
+    >>> interval_data[1, 0, 0]     # aligned axis (1) indexed by an int -> raw value
+    6
+
+Splicing
+========
+
+Splicing produces a new :py:class:`~genome_kit.IntervalData` in which the
+``interval`` and the ``data`` have been sliced together, so they remain aligned.
+There are three ways to splice.
+
+By slice
+~~~~~~~~
+
+A Python ``slice`` selects a sub-range along the aligned axis. The backing
+interval is narrowed to the matching genomic sub-range
+
+.. code-block:: python
+
+    >>> interval = gk.Interval("chr1", "+", 100, 103, "hg19")
+    >>> data = np.arange(30).reshape(3, 10)
+    >>> interval_data = gk.IntervalData(interval, data)
+    >>> sub = interval_data[1:]            # drop the first position
+    >>> sub.interval
+    Interval("chr1", "+", 101, 103, "hg19")
+    >>> len(sub)
+    2
+
+A negative step reverses the slice **and** flips the strand of the interval, so
+the data and the interval stay consistent — position 0 of the result is still
+its 5' end
+
+.. code-block:: python
+
+    >>> rev = interval_data[::-1]
+    >>> rev.interval.strand
+    '-'
+
+Only steps of ``±1`` are supported. A discontinuous step (e.g. ``[::2]``) raises
+``KeyError``, since no contiguous interval can describe every other base.
+
+When ``axis > 0``, a bare slice is ambiguous (it does not say what to do with the
+other axes), so ``interval_data[1:]`` raises ``IndexError``. Use a tuple that
+slices the aligned axis explicitly instead
+
+.. code-block:: python
+
+    >>> data = np.arange(30).reshape(5, 3, 2)
+    >>> interval_data = gk.IntervalData(interval, data, axis=1)
+    >>> sub = interval_data[:, 1:, ...]    # slice the aligned axis (1)
+    >>> sub.interval
+    Interval("chr1", "+", 101, 103, "hg19")
+
+Here the tuple's entry on the aligned axis is a ``slice``, so the whole tuple is
+applied to ``data`` and the interval is narrowed to match that slice.
+
+By Interval or DIS
+~~~~~~~~~~~~~~~~~~~
+
+The most convenient form is to index with a genomic key. The key selects the
+portion of the data corresponding to that genomic region, and the returned
+:py:class:`~genome_kit.IntervalData` is indexed by the key itself
+
+.. code-block:: python
+
+    >>> base = gk.Interval("chr1", "+", 100, 103, "hg19")
+    >>> data = np.arange(30).reshape(3, 10)
+    >>> interval_data = gk.IntervalData(base, data)
+    >>> key = base.expand(-1, 0)           # drop one base at the 5' end
+    >>> sub = interval_data[key]
+    >>> sub.interval == key
+    True
+    >>> np.array_equal([x for x in sub], data[1:])
+    True
+
+The key must be contained within the backing interval; otherwise ``IndexError``
+is raised.
+
+Indexing with the interval on the **opposite strand** reverses the data, so the
+result is read 5'→3' along the requested strand
+
+.. code-block:: python
+
+    >>> rev = interval_data[base.as_opposite_strand()]
+    >>> rev.interval.strand
+    '-'
+    >>> np.array_equal([x for x in rev], data[::-1])
+    True
+
+A zero-length key (e.g. ``base.end5``) yields an empty result, and a
+full-length key round-trips to the original data.
+
+Lifting genomic keys onto a DIS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When the :py:class:`~genome_kit.IntervalData` is backed by a
+:py:class:`~genome_kit.DisjointIntervalSequence`, you can index it with a plain
+genomic :py:class:`~genome_kit.Interval`. The key is first *lifted* into the DIS
+coordinate space via
+:py:meth:`~genome_kit.DisjointIntervalSequence.lift_interval`, so a genomic region
+is translated into spliced-coordinate offsets before the data is sliced
+
+.. code-block:: python
+
+    >>> dis = DisjointIntervalSequence.from_transcript(transcript)
+    >>> data = np.arange(len(dis))
+    >>> interval_data = gk.IntervalData.from_dis(dis, data)
+    >>> exon = transcript.exons[0].interval
+    >>> sub = interval_data[exon]          # genomic key lifted into DIS space
+
+If the genomic key is not fully contained within the DIS segment — it straddles
+the segment edge, lands in an intron, or lies on a mismatched chromosome or
+reference genome — the lift fails and :py:class:`~genome_kit.IntervalData`
+surfaces it as an ``IndexError`` (``"... does not contain ..."``), matching the
+behavior of an ``Interval``-backed :py:class:`~genome_kit.IntervalData`.
+
+Indexing a DIS-backed :py:class:`~genome_kit.IntervalData` with a
+:py:class:`~genome_kit.DisjointIntervalSequence` key (sharing the same coordinate
+space) works too and skips the lift, since the key is already in DIS coordinates.
+
+Assigning Data
+==============
+
+Assignment mirrors indexing. A key that is a ``slice`` or a tuple is forwarded
+directly to the underlying array
+
+.. code-block:: python
+
+    >>> interval_data[0] = interval_data[0].transpose()
+
+An :py:class:`~genome_kit.Interval` or
+:py:class:`~genome_kit.DisjointIntervalSequence` key is first resolved to the
+corresponding slice of the aligned axis (lifting the key onto the backing DIS if
+necessary), then assigned into ``data``
+
+.. code-block:: python
+
+    >>> base = gk.Interval("chr1", "+", 100, 103, "hg19")
+    >>> data = np.arange(30).reshape(3, 10)
+    >>> interval_data = gk.IntervalData(base, data.copy())
+    >>> interval_data[base.expand(-1, 0)] = 0    # zero out all but the first position
+    >>> np.array_equal(interval_data.data[0], data[0])
+    True
+    >>> bool(np.all(interval_data.data[1:] == 0))
+    True
+
+Assignment mutates the existing ``data`` array in place; it does not create a new
+:py:class:`~genome_kit.IntervalData`.
+
+Attributes and Representation
+=============================
+
+An :py:class:`~genome_kit.IntervalData` exposes its components directly:
+
+- ``interval`` — the backing :py:class:`~genome_kit.Interval` or
+  :py:class:`~genome_kit.DisjointIntervalSequence`.
+- ``data`` — the underlying array.
+- ``axis`` — the aligned axis.
+
+``len(interval_data)`` returns ``len(interval)`` (the number of aligned
+positions), and ``str(interval_data)`` shows the data type together with the
+interval it is indexed by
+
+.. code-block:: python
+
+    >>> str(interval_data)
+    "<<class 'numpy.ndarray'> indexed by <Interval(\"chr1\", \"+\", 100, 103, \"hg19\")>>"
+
+See Also
+========
+
+- :ref:`diseq` — the coordinate system used when an
+  :py:class:`~genome_kit.IntervalData` is backed by a
+  :py:class:`~genome_kit.DisjointIntervalSequence`.
+- :ref:`tracks <tracks>` — similar to an :py:class:`~genome_kit.IntervalData`,
+  but on-disk and for a whole genome.

--- a/docs-src/interval_data.rst
+++ b/docs-src/interval_data.rst
@@ -75,23 +75,6 @@ the genomic span
     >>> data = np.arange(len(dis))
     >>> interval_data = gk.IntervalData.from_dis(dis, data)
 
-From a sequence of Intervals
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-:py:meth:`~genome_kit.IntervalData.from_intervals` builds the backing DIS for you
-from a set of non-overlapping intervals on the same chromosome, strand, and
-reference genome
-
-.. code-block:: python
-
-    >>> exons = [e.interval for e in transcript.exons]
-    >>> data = np.arange(sum(len(e) for e in exons))
-    >>> interval_data = gk.IntervalData.from_intervals(exons, data)
-
-This is equivalent to calling
-:py:meth:`~genome_kit.DisjointIntervalSequence.from_intervals` and then
-:py:meth:`~genome_kit.IntervalData.from_dis`.
-
 The aligned axis
 ~~~~~~~~~~~~~~~~~
 

--- a/docs-src/interval_data.rst
+++ b/docs-src/interval_data.rst
@@ -44,36 +44,30 @@ much like a :ref:`track <tracks>`. Indexing then falls into two categories:
 Construction
 ============
 
-From a single Interval
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-The most direct case is a contiguous genomic region. The aligned axis of ``data``
-must have the same length as the interval
+An :py:class:`~genome_kit.IntervalData` can be backed two ways: by an
+:py:class:`~genome_kit.Interval` for a contiguous genomic region, or by a
+:py:class:`~genome_kit.DisjointIntervalSequence` for a discontiguous one (e.g. a
+transcript's exons). Either way, the aligned axis of ``data`` must have the same
+length as the backing object — for a DIS that is the length of the segment
+(``len(dis)``)
 
 .. code-block:: python
 
+    >>> # backed by an Interval: one value per base of a contiguous region
     >>> interval = gk.Interval("chr7", "+", 100000, 100500, "hg19")
-    >>> data = np.arange(len(interval))          # length 500, one value per base
+    >>> data = np.arange(len(interval))          # length 500
     >>> interval_data = gk.IntervalData(interval, data)
-
-:py:meth:`~genome_kit.IntervalData.from_interval` is an explicit alias for this
-case and behaves identically to the constructor.
-
-From a DisjointIntervalSequence
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-When the data describes a discontiguous region (e.g. a transcript's exons), back the
-:py:class:`~genome_kit.IntervalData` with a
-:py:class:`~genome_kit.DisjointIntervalSequence`. The aligned axis must match the
-DIS segment length (``len(dis)``), i.e. the length of the *spliced* sequence, not
-the genomic span
-
-.. code-block:: python
-
+    >>>
+    >>> # backed by a DIS: one value per base of the spliced sequence
     >>> from genome_kit.diseq import DisjointIntervalSequence
     >>> dis = DisjointIntervalSequence.from_transcript(transcript)
     >>> data = np.arange(len(dis))
     >>> interval_data = gk.IntervalData.from_dis(dis, data)
+
+The constructor takes either kind of backing object;
+:py:meth:`~genome_kit.IntervalData.from_interval` and
+:py:meth:`~genome_kit.IntervalData.from_dis` are explicit aliases that behave
+identically to it.
 
 The aligned axis
 ~~~~~~~~~~~~~~~~~
@@ -88,9 +82,6 @@ Data is rarely one-dimensional. The ``axis`` argument tells
     >>> interval_data = gk.IntervalData(interval, data, axis=1)
     >>> len(interval_data)
     500
-
-If your aligned axis is not where you need it, use ``axis`` to point at it, or
-reorder the array up-front and leave ``axis`` at its default.
 
 Array Indexing
 ==============
@@ -169,9 +160,6 @@ slices the aligned axis explicitly instead
     >>> sub.interval
     Interval("chr1", "+", 101, 103, "hg19")
 
-Here the tuple's entry on the aligned axis is a ``slice``, so the whole tuple is
-applied to ``data`` and the interval is narrowed to match that slice.
-
 By Interval or DIS
 ~~~~~~~~~~~~~~~~~~~
 
@@ -226,15 +214,12 @@ is translated into spliced-coordinate offsets before the data is sliced
     >>> exon = transcript.exons[0].interval
     >>> sub = interval_data[exon]          # genomic key lifted into DIS space
 
-If the genomic key is not fully contained within the DIS segment — it straddles
-the segment edge, lands in an intron, or lies on a mismatched chromosome or
-reference genome — the lift fails and :py:class:`~genome_kit.IntervalData`
-surfaces it as an ``IndexError`` (``"... does not contain ..."``), matching the
-behavior of an ``Interval``-backed :py:class:`~genome_kit.IntervalData`.
+The genomic key must be fully contained within the DIS segment, otherwise
+an ``IndexError`` is raised.
 
-Indexing a DIS-backed :py:class:`~genome_kit.IntervalData` with a
-:py:class:`~genome_kit.DisjointIntervalSequence` key (sharing the same coordinate
-space) works too and skips the lift, since the key is already in DIS coordinates.
+It is also possible to index a DIS-backed :py:class:`~genome_kit.IntervalData` with a
+:py:class:`~genome_kit.DisjointIntervalSequence` key, but they must share the same
+coordinate intervals.
 
 Assigning Data
 ==============
@@ -261,6 +246,31 @@ necessary), then assigned into ``data``
     True
     >>> bool(np.all(interval_data.data[1:] == 0))
     True
+
+A ``list`` of non-overlapping :py:class:`~genome_kit.Interval` objects assigns
+across several regions at once. The list is normalized 5'->3' first, so the order
+it is given in does not matter.
+
+When assigning via an Interval-like or ``List`` object, ``value`` must
+take one of three shapes:
+
+- ``data``'s shape with the aligned axis resized to the key's length — one value
+  per selected position, i.e. the shape of ``interval_data[key].data``
+- ``data``'s shape with the aligned axis removed — a single position's worth of
+  data, broadcast to every position the key selects.
+- a scalar, broadcast to everything.
+
+.. code-block:: python
+
+    >>> exons = [gk.Interval("chr1", "+", 100, 102, "hg19"),
+    ...          gk.Interval("chr1", "+", 104, 106, "hg19")]
+    >>> base = gk.Interval("chr1", "+", 100, 106, "hg19")
+    >>> interval_data = gk.IntervalData(base, np.zeros((6, 10), dtype=int))
+    >>> interval_data[exons] = np.arange(40).reshape(4, 10)   # one value per position
+    >>> interval_data[exons] = np.arange(10)                  # one row, to all four
+    >>> interval_data[exons] = 0                              # scalar
+
+Any other shape raises ``ValueError`` to prevent silent bugs due to ambiguous assignment.
 
 Assignment mutates the existing ``data`` array in place; it does not create a new
 :py:class:`~genome_kit.IntervalData`.

--- a/docs-src/interval_data.rst
+++ b/docs-src/interval_data.rst
@@ -159,6 +159,8 @@ slices the aligned axis explicitly instead
     >>> sub = interval_data[:, 1:, ...]    # slice the aligned axis (1)
     >>> sub.interval
     Interval("chr1", "+", 101, 103, "hg19")
+    >>> np.array_equal(interval_data[:, 1:, ...].data, data[:, 1:, ...])
+    True  # A slice is forwarded to the underlying array
 
 By Interval or DIS
 ~~~~~~~~~~~~~~~~~~~

--- a/docs-src/quickstart.rst
+++ b/docs-src/quickstart.rst
@@ -152,6 +152,8 @@ plus several other attributes::
     >>> exon.next_exon
     <Exon 2/27 of ENST00000003084.6>
 
+.. _tracks:
+
 Tracks
 ------
 

--- a/genome_kit/__init__.py
+++ b/genome_kit/__init__.py
@@ -25,6 +25,7 @@ from .genome_annotation import (
 from .genome_dna import GenomeDNA
 from .genome_track import GenomeTrack, GenomeTrackBuilder
 from .interval import Interval
+from .interval_data import IntervalData
 from .jralign import (
     JReadAlignments,
     JunctionReadAlignment,
@@ -84,6 +85,7 @@ __all__ = [
     "GenomeTrackBuilder",
     "gk_data",
     "Interval",
+    "IntervalData",
     "Intron",
     "IntronTable",
     "JReadAlignments",

--- a/genome_kit/diseq.py
+++ b/genome_kit/diseq.py
@@ -475,6 +475,37 @@ class DisjointIntervalSequence:
             end=max(end5, end3),
         )
 
+    def cut(self, start: int, end: int) -> "DisjointIntervalSequence":
+        """Return a new DIS with the segment set to absolute coordinate-space indices.
+
+        The coordinate space and ``on_coordinate_strand`` are preserved; only the
+        segment's :py:attr:`start` and :py:attr:`end` indices change. ``start`` and
+        ``end`` are absolute, 0-based, half-open indices into the coordinate space,
+        so ``start`` must be the lower index regardless of strand. Indices
+        outside ``[0, coordinate_length]`` are permitted and represent flanking positions
+        extrapolated past the coordinate space's edges.
+
+        Parameters
+        ----------
+        start
+            New segment start index in the coordinate space.
+        end
+            New segment end index in the coordinate space (exclusive).
+
+        Raises
+        ------
+        ValueError
+            If ``start`` is greater than ``end``.
+        """
+        return DisjointIntervalSequence(
+            self._coordinate_intervals,
+            coord_name=self._coord_metadata.name,
+            segment_name=self._segment_metadata.name,
+            on_coordinate_strand=self.on_coordinate_strand,
+            start=start,
+            end=end,
+        )
+
     def shift(self, amount: int) -> "DisjointIntervalSequence":
         """Shift the segment downstream by amount (negative shifts upstream).
         The coordinate space is unchanged. Only the segment indices move.

--- a/genome_kit/diseq.py
+++ b/genome_kit/diseq.py
@@ -415,9 +415,15 @@ class DisjointIntervalSequence:
             # i.e. the internal boundary between two coord intervals.
             upstream = ivs[interval_index - 1]
             if on_plus:
-                return [upstream.end, iv.start]  # indices ordered 5' -> 3' w.r.t segment strand
+                return [
+                    upstream.end,
+                    iv.start,
+                ]  # indices ordered 5' -> 3' w.r.t segment strand
             else:
-                return [upstream.start, iv.end]  # indices ordered 5' -> 3' w.r.t segment strand
+                return [
+                    upstream.start,
+                    iv.end,
+                ]  # indices ordered 5' -> 3' w.r.t segment strand
 
         if on_plus:
             return [iv.end - abs(delta)]
@@ -569,9 +575,7 @@ class DisjointIntervalSequence:
         coord_ivs = list(self._coordinate_intervals)
         iv0, ivn = coord_ivs[0], coord_ivs[-1]
         if len(coord_ivs) == 1:
-            coord_ivs = [
-                iv0.expand(upstream, dnstream)  # iv0 is ivn
-            ]
+            coord_ivs = [iv0.expand(upstream, dnstream)]  # iv0 is ivn
         else:
             coord_ivs[0] = iv0.expand(upstream, 0)
             coord_ivs[-1] = ivn.expand(0, dnstream)
@@ -582,7 +586,7 @@ class DisjointIntervalSequence:
             segment_name=self._segment_metadata.name,
             on_coordinate_strand=self.on_coordinate_strand,
             start=new_start,
-            end=new_end
+            end=new_end,
         )
 
     def upstream_of(self, other: "DisjointIntervalSequence") -> bool:
@@ -639,13 +643,11 @@ class DisjointIntervalSequence:
         return self._start >= other.start and self._end <= other.end
 
     def is_same_strand(self) -> bool:
-        """True if the segment is on the same strand as the coordinate intervals.
-        """
+        """True if the segment is on the same strand as the coordinate intervals."""
         return self.on_coordinate_strand
 
     def is_positive_strand(self) -> bool:
-        """True if the segment is on the positive strand.
-        """
+        """True if the segment is on the positive strand."""
         if self.strand == "+":
             return True
         return False
@@ -840,7 +842,9 @@ class DisjointIntervalSequence:
             cumulative += len(iv)
         assert False, "Position not found in any interval"
 
-    def lift_interval(self, other: Interval) -> "DisjointIntervalSequence | None":
+    def lift_interval(
+        self, other: Interval, intersect_on_lift: bool = False
+    ) -> "DisjointIntervalSequence | None":
         """Lift a genomic :py:class:`~genome_kit.Interval` onto this DIS's segment.
 
         The interval's genomic span is mapped into DIS coordinate-space indices
@@ -851,6 +855,13 @@ class DisjointIntervalSequence:
         ``on_coordinate_strand`` reflects whether ``other`` is on the
         coordinate strand, so an interval on the strand opposite this DIS's
         segment lifts to an opposite-strand segment.
+
+        Parameters
+        ----------
+        intersect_on_lift
+            If True, the lifted interval is intersected with this DIS's segment.
+            Default is False, and results in a ValueError if the interval is not fully
+            contained within the DIS's segment.
 
         Raises
         ------
@@ -866,6 +877,25 @@ class DisjointIntervalSequence:
             raise ValueError(
                 f"Interval reference_genome {other.reference_genome!r} does not "
                 f"match DIS reference_genome {self.reference_genome!r}"
+            )
+        lowered = self.lower()
+        # Need the intervals on same strand as other to check if other is within any of
+        # the lowered intervals, since other may be on the opposite strand.
+        lowered_ivs_on_same_strand_as_other = (
+            lowered
+            if other.strand == self.strand
+            else [iv.as_opposite_strand() for iv in lowered]
+        )
+        # Since DIS segment lowered intervals are not contiguous, if other is not
+        # fully contained within one of the lowered intervals then it is not fully
+        # contained within the DIS segment.
+        if (
+            not intersect_on_lift
+            and sum(other.within(iv) for iv in lowered_ivs_on_same_strand_as_other) != 1
+        ):
+            raise ValueError(
+                f"Interval {other} lies outside the bases defined by the segment of this DIS. "
+                f"Set intersect_on_lift=True to allow lifting and intersecting with the DIS segment."
             )
 
         if self.coord_strand == "+":

--- a/genome_kit/diseq.py
+++ b/genome_kit/diseq.py
@@ -846,11 +846,11 @@ class DisjointIntervalSequence:
             self.reference_genome,
         )
 
-    def _lift_position(self, pos: int, lift_pos_in_genomic_gap: bool = False) -> int | None:
+    def _lift_position(self, pos: int, clip: bool = False) -> int | None:
         """Map a genomic position to a DIS index in this coordinate space.
 
         Positions outside the coord intervals are linearly extrapolated from
-        the nearest outer edge. If ``lift_pos_in_genomic_gap`` is True, positions
+        the nearest outer edge. If ``clip`` is True, positions
         in a gap between coord intervals are clipped to the cumulative end of the
         previous interval (i.e. the boundary index), otherwise they return None.
         """
@@ -866,7 +866,7 @@ class DisjointIntervalSequence:
                 if iv.start <= pos <= iv.end:
                     return cumulative + (pos - iv.start)
                 if pos < iv.start:
-                    return cumulative if lift_pos_in_genomic_gap else None
+                    return cumulative if clip else None
                 cumulative += len(iv)
             assert False, "Position not found in any interval"
         # minus
@@ -879,7 +879,7 @@ class DisjointIntervalSequence:
             if iv.start <= pos <= iv.end:
                 return cumulative + (iv.end - pos)
             if pos > iv.end:
-                return cumulative if lift_pos_in_genomic_gap else None
+                return cumulative if clip else None
             cumulative += len(iv)
         assert False, "Position not found in any interval"
 
@@ -948,8 +948,8 @@ class DisjointIntervalSequence:
             # On minus, lower genomic position maps to higher DIS index.
             other_corrected_start = other.end
             other_corrected_end = other.start
-        lift_start = self._lift_position(other_corrected_start, lift_pos_in_genomic_gap=False)
-        lift_end = self._lift_position(other_corrected_end, lift_pos_in_genomic_gap=False)
+        lift_start = self._lift_position(other_corrected_start, clip=False)
+        lift_end = self._lift_position(other_corrected_end, clip=False)
 
         if not intersect_on_lift and (lift_start is None or lift_end is None):
             raise ValueError(
@@ -963,8 +963,8 @@ class DisjointIntervalSequence:
         if not intersect_on_lift:
             assert lift_start is not None and lift_end is not None
 
-        seg_start = self._lift_position(other_corrected_start, lift_pos_in_genomic_gap=intersect_on_lift)
-        seg_end = self._lift_position(other_corrected_end, lift_pos_in_genomic_gap=intersect_on_lift)
+        seg_start = self._lift_position(other_corrected_start, clip=intersect_on_lift)
+        seg_end = self._lift_position(other_corrected_end, clip=intersect_on_lift)
         # lifted interval is entirely upstream or downstream of the DIS segment
         if seg_end < self.start or seg_start > self.end:
             return None

--- a/genome_kit/diseq.py
+++ b/genome_kit/diseq.py
@@ -960,7 +960,8 @@ class DisjointIntervalSequence:
             return None
         # It should only be permissible to have a single None when intersect_on_lift=True,
         # since it's possible to lift an interval that is partially in a gap between coord intervals
-        assert lift_start is not None and lift_end is not None if not intersect_on_lift else True
+        if not intersect_on_lift:
+            assert lift_start is not None and lift_end is not None
 
         seg_start = self._lift_position(other_corrected_start, lift_pos_in_genomic_gap=intersect_on_lift)
         seg_end = self._lift_position(other_corrected_end, lift_pos_in_genomic_gap=intersect_on_lift)
@@ -974,7 +975,8 @@ class DisjointIntervalSequence:
         intersected_start = max(seg_start, self._start)
         intersected_end = min(seg_end, self._end)
         assert intersected_start <= intersected_end
-        assert intersected_start == seg_start and intersected_end == seg_end if not intersect_on_lift else True
+        if not intersect_on_lift:
+            assert intersected_start == seg_start and intersected_end == seg_end
 
         return DisjointIntervalSequence(
             self._coordinate_intervals,

--- a/genome_kit/diseq.py
+++ b/genome_kit/diseq.py
@@ -958,12 +958,15 @@ class DisjointIntervalSequence:
             )
         if intersect_on_lift and lift_start is None and lift_end is None:
             return None
-        # lifted interval is entirely upstream or downstream of the DIS segment
-        if lift_end < self.start or lift_start > self.end:
-            return None
+        # It should only be permissible to have a single None when intersect_on_lift=True,
+        # since it's possible to lift an interval that is partially in a gap between coord intervals
+        assert lift_start is not None and lift_end is not None if not intersect_on_lift else True
 
         seg_start = self._lift_position(other_corrected_start, lift_pos_in_genomic_gap=intersect_on_lift)
         seg_end = self._lift_position(other_corrected_end, lift_pos_in_genomic_gap=intersect_on_lift)
+        # lifted interval is entirely upstream or downstream of the DIS segment
+        if seg_end < self.start or seg_start > self.end:
+            return None
         assert seg_start is not None and seg_end is not None
 
         # Clip to self's segment via half-open intersection

--- a/genome_kit/diseq.py
+++ b/genome_kit/diseq.py
@@ -673,8 +673,15 @@ class DisjointIntervalSequence:
             )
         return self._start >= other.start and self._end <= other.end
 
-    def is_same_strand(self) -> bool:
-        """True if the segment is on the same strand as the coordinate intervals."""
+    def contains(self, other: "DisjointIntervalSequence") -> bool:
+        """True if self's segment contains other's segment.
+
+        Requires the same coordinate space and same on_coordinate_strand.
+        """
+        return other.within(self)
+
+    def is_on_coordinate_strand(self) -> bool:
+        """True if the segment is on the coordinate strand."""
         return self.on_coordinate_strand
 
     def is_positive_strand(self) -> bool:
@@ -691,7 +698,7 @@ class DisjointIntervalSequence:
         """
         if self.is_positive_strand():
             return self
-        return self.flip_strand()
+        return self.as_opposite_strand()
 
     def as_negative_strand(self) -> "DisjointIntervalSequence":
         """Return a DIS with the segment on the negative strand.
@@ -701,33 +708,36 @@ class DisjointIntervalSequence:
         """
         if not self.is_positive_strand():
             return self
-        return self.flip_strand()
+        return self.as_opposite_strand()
 
-    def as_opposite_strand(self) -> "DisjointIntervalSequence":
-        """Return a DIS with the segment on the opposite strand.
+    def as_off_coordinate_strand(self) -> "DisjointIntervalSequence":
+        """Return a DIS with the segment on the strand opposite the coordinate strand.
 
-        Returns ``self`` if already on the opposite strand. The coordinate
-        intervals are unchanged; only the segment strand is affected.
+        Returns ``self`` if the segment is already off the coordinate strand.
+        The coordinate intervals are unchanged; only the segment strand is
+        affected.
         """
         if not self.on_coordinate_strand:
             return self
-        return self.flip_strand()
+        return self.as_opposite_strand()
 
-    def as_same_strand(self) -> "DisjointIntervalSequence":
+    def as_on_coordinate_strand(self) -> "DisjointIntervalSequence":
         """Return a DIS with the segment on the coordinate strand.
 
-        Returns ``self`` if already on the coordinate strand. The coordinate
-        intervals are unchanged; only the segment strand is affected.
+        Returns ``self`` if the segment is already on the coordinate strand.
+        The coordinate intervals are unchanged; only the segment strand is
+        affected.
         """
         if self.on_coordinate_strand:
             return self
-        return self.flip_strand()
+        return self.as_opposite_strand()
 
-    def flip_strand(self) -> "DisjointIntervalSequence":
-        """Return a new DIS with ``on_coordinate_strand`` toggled.
+    def as_opposite_strand(self) -> "DisjointIntervalSequence":
+        """Return a new DIS with the segment on the opposite strand.
 
-        The coordinate intervals are unchanged. The segment's
-        ``on_coordinate_strand`` is flipped.
+        Toggles the segment's ``on_coordinate_strand`` (matching
+        :py:meth:`~genome_kit.Interval.as_opposite_strand`). The coordinate
+        intervals are unchanged; only the segment strand is affected.
         """
         return DisjointIntervalSequence(
             self._coordinate_intervals,
@@ -836,13 +846,13 @@ class DisjointIntervalSequence:
             self.reference_genome,
         )
 
-    def _lift_position(self, pos: int) -> int:
+    def _lift_position(self, pos: int, lift_pos_in_genomic_gap: bool = False) -> int | None:
         """Map a genomic position to a DIS index in this coordinate space.
 
         Positions outside the coord intervals are linearly extrapolated from
-        the nearest outer edge. Positions in a gap between coord intervals
-        are clipped to the cumulative end of the previous interval (i.e. the
-        boundary index).
+        the nearest outer edge. If ``lift_pos_in_genomic_gap`` is True, positions
+        in a gap between coord intervals are clipped to the cumulative end of the
+        previous interval (i.e. the boundary index), otherwise they return None.
         """
         ivs = self._coordinate_intervals
         coord_len = self.coordinate_length
@@ -856,7 +866,7 @@ class DisjointIntervalSequence:
                 if iv.start <= pos <= iv.end:
                     return cumulative + (pos - iv.start)
                 if pos < iv.start:
-                    return cumulative
+                    return cumulative if lift_pos_in_genomic_gap else None
                 cumulative += len(iv)
             assert False, "Position not found in any interval"
         # minus
@@ -869,7 +879,7 @@ class DisjointIntervalSequence:
             if iv.start <= pos <= iv.end:
                 return cumulative + (iv.end - pos)
             if pos > iv.end:
-                return cumulative
+                return cumulative if lift_pos_in_genomic_gap else None
             cumulative += len(iv)
         assert False, "Position not found in any interval"
 
@@ -929,19 +939,39 @@ class DisjointIntervalSequence:
                 f"Set intersect_on_lift=True to allow lifting and intersecting with the DIS segment."
             )
 
+        # Set variables for the other interval's start and end positions in the DIS
+        # coordinate space to keep logic simple
         if self.coord_strand == "+":
-            seg_start = self._lift_position(other.start)
-            seg_end = self._lift_position(other.end)
+            other_corrected_start = other.start
+            other_corrected_end = other.end
         else:
             # On minus, lower genomic position maps to higher DIS index.
-            seg_start = self._lift_position(other.end)
-            seg_end = self._lift_position(other.start)
+            other_corrected_start = other.end
+            other_corrected_end = other.start
+        lift_start = self._lift_position(other_corrected_start, lift_pos_in_genomic_gap=False)
+        lift_end = self._lift_position(other_corrected_end, lift_pos_in_genomic_gap=False)
 
-        # Clip to self's segment via half-open intersection.
+        if not intersect_on_lift and (lift_start is None or lift_end is None):
+            raise ValueError(
+                f"Interval {other} lies between the intervals that define the segment of this DIS. "
+                f"Set intersect_on_lift=True to allow lifting and intersecting with the DIS segment."
+            )
+        if intersect_on_lift and lift_start is None and lift_end is None:
+            return None
+        # lifted interval is entirely upstream or downstream of the DIS segment
+        if lift_end < self.start or lift_start > self.end:
+            return None
+
+        seg_start = self._lift_position(other_corrected_start, lift_pos_in_genomic_gap=intersect_on_lift)
+        seg_end = self._lift_position(other_corrected_end, lift_pos_in_genomic_gap=intersect_on_lift)
+        assert seg_start is not None and seg_end is not None
+
+        # Clip to self's segment via half-open intersection
+        # (no-op if intersect_on_lift=False due to prior checks)
         intersected_start = max(seg_start, self._start)
         intersected_end = min(seg_end, self._end)
-        if intersected_start >= intersected_end:
-            return None
+        assert intersected_start <= intersected_end
+        assert intersected_start == seg_start and intersected_end == seg_end if not intersect_on_lift else True
 
         return DisjointIntervalSequence(
             self._coordinate_intervals,

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -10,13 +10,13 @@ IntervalLike: TypeAlias = Interval | DisjointIntervalSequence
 
 
 class IntervalData:
-    r"""
-    Associates a data sequence with the genomic interval for convenient splicing.
+    r"""Associates a data sequence with a genomic interval for convenient splicing.
 
-    Array indexing via [index] will act directly on `data`. Array splicing (via ``slice`` or
-    ``Interval`` or ``DisjointIntervalSequence``) will splice both the `interval` and `data`;
-    the associated `data` is assumed to beunstranded 5" to 3", so splicing via the
-    opposite strand will reverse the `data` (similar to tracks).
+    Array indexing via ``[index]`` acts directly on ``data``. Array splicing (via
+    ``slice``, :py:class:`~genome_kit.Interval`, or
+    :py:class:`~genome_kit.DisjointIntervalSequence`) splices both the ``interval``
+    and ``data``; the associated ``data`` is assumed to be unstranded 5'->3', so
+    splicing via the opposite strand will reverse the ``data`` (similar to tracks).
 
     Examples
     --------
@@ -47,25 +47,25 @@ class IntervalData:
 
         Parameters
         ----------
-        interval : :py:class:`~genome_kit.Interval` or :py:class:`~genome_kit.DisjointIntervalSequence`
-            The genomic interval or disjoint interval(s) of interest.
-
-        data : array_like
-            Must be the same dimension as `interval` and ordered from 5" to 3".
-            If required, `axis` can be used to realign;
+        interval
+            The genomic :py:class:`~genome_kit.Interval` or
+            :py:class:`~genome_kit.DisjointIntervalSequence` of interest.
+        data
+            An ``array_like`` the same length as ``interval`` along ``axis`` and
+            ordered 5'->3'. If required, ``axis`` can be used to realign;
             otherwise, :func:`~numpy.rollaxis` can be used to reindex.
-
-        axis : optional
-            Axis of the multidimensional `data` to align to `interval`. Defaults to 0.
+        axis
+            Axis of the multidimensional ``data`` aligned to ``interval``.
+            Defaults to 0.
 
         Raises
         ------
         IndexError
-            `axis` cannot be negative
+            If ``axis`` is negative.
         ValueError
-            The `data` aligned to the `axis` is not the same dimension as the `interval`.
+            If the length of ``data`` along ``axis`` does not match ``interval``.
         TypeError
-            `interval` is neither an :py:class:`~genome_kit.Interval` nor a
+            If ``interval`` is neither an :py:class:`~genome_kit.Interval` nor a
             :py:class:`~genome_kit.DisjointIntervalSequence`.
         """
 
@@ -100,11 +100,11 @@ class IntervalData:
 
         Parameters
         ----------
-        interval : :py:class:`~genome_kit.Interval`
-            The genomic interval of interest.
-        data : array_like
+        interval
+            The genomic :py:class:`~genome_kit.Interval` of interest.
+        data
             See :py:meth:`__init__`.
-        axis : optional
+        axis
             See :py:meth:`__init__`.
         """
         return cls(interval, data, axis)
@@ -115,13 +115,13 @@ class IntervalData:
 
         Parameters
         ----------
-        dis : :py:class:`~genome_kit.DisjointIntervalSequence`
-            The DIS whose segment defines the genomic interval(s).
-        data : array_like
+        dis
+            The :py:class:`~genome_kit.DisjointIntervalSequence` whose segment
+            defines the genomic interval(s).
+        data
             See :py:meth:`__init__`.
-        axis : optional
+        axis
             See :py:meth:`__init__`.
-
         """
         return cls(dis, data, axis)
 
@@ -135,21 +135,39 @@ class IntervalData:
 
         Parameters
         ----------
-        intervals : Sequence[:py:class:`~genome_kit.Interval`]
-            Non-overlapping intervals on the same chromosome, strand, and reference genome.
-        data : array_like
+        intervals
+            Non-overlapping :py:class:`~genome_kit.Interval` objects on the same
+            chromosome, strand, and reference genome.
+        data
             See :py:meth:`__init__`.
-        axis : optional
+        axis
             See :py:meth:`__init__`.
-
         """
         return cls(DisjointIntervalSequence.from_intervals(intervals), data, axis)
 
     def __len__(self) -> int:
+        """Return the number of aligned positions, i.e. ``len(interval)``."""
         return len(self.interval)
 
     @staticmethod
     def _get_interval(interval: IntervalLike, slice_index: slice) -> IntervalLike:
+        """Return the sub-interval selected by a slice along the aligned axis.
+
+        A negative step reverses the slice and flips the result to the opposite
+        strand, so it stays ordered 5'->3'.
+
+        Parameters
+        ----------
+        interval
+            The interval-like object being sliced.
+        slice_index
+            The slice applied to the aligned axis.
+
+        Raises
+        ------
+        KeyError
+            If ``slice_index`` has a step other than ``±1``.
+        """
         length = len(interval)
         start, stop, step = slice_index.indices(length)
         if abs(step) != 1:
@@ -168,6 +186,22 @@ class IntervalData:
 
     @staticmethod
     def _get_slice(interval: IntervalLike, interval_slice: IntervalLike) -> slice:
+        """Return the aligned-axis slice that selects an interval-like key.
+
+        A key on the opposite strand produces a reversed (negative-step) slice.
+
+        Parameters
+        ----------
+        interval
+            The backing interval-like object.
+        interval_slice
+            The interval-like key to locate within ``interval``.
+
+        Raises
+        ------
+        IndexError
+            If ``interval`` does not contain ``interval_slice``.
+        """
         if interval_slice.strand == interval.strand:
             if not interval.contains(interval_slice):
                 raise IndexError(
@@ -195,7 +229,7 @@ class IntervalData:
         """Normalize an interval-like key into the backing interval's coordinate space.
 
         When this IntervalData is backed by a
-        :py:class:`~genome_kit.DisjointIntervalSequence` and `key` is a genomic
+        :py:class:`~genome_kit.DisjointIntervalSequence` and ``key`` is a genomic
         :py:class:`~genome_kit.Interval`, the key is lifted (via
         :py:meth:`~genome_kit.DisjointIntervalSequence.lift_interval`) so that
         indexing happens in the DIS's flattened coordinate space. All other cases
@@ -205,7 +239,7 @@ class IntervalData:
         Raises
         ------
         IndexError
-            If `key` is not fully contained within the backing DIS's segment
+            If ``key`` is not fully contained within the backing DIS's segment
             (see :py:meth:`~genome_kit.DisjointIntervalSequence.lift_interval`).
         """
         if isinstance(self.interval, DisjointIntervalSequence) and isinstance(
@@ -229,6 +263,15 @@ class IntervalData:
     def __getitem__(
         self, item: slice | tuple | int | IntervalLike
     ) -> "IntervalData" | Sequence:
+        """Index the data, or splice both the interval and data together.
+
+        An integer (or a tuple whose aligned-axis entry is an integer) indexes
+        ``data`` directly and returns the raw array value. A ``slice``, an
+        :py:class:`~genome_kit.Interval`, or a
+        :py:class:`~genome_kit.DisjointIntervalSequence` slices both ``interval``
+        and ``data`` and returns a new :py:class:`IntervalData`. Splicing onto
+        the opposite strand reverses ``data``.
+        """
         data = self.data
         axis = self.axis
 
@@ -256,14 +299,23 @@ class IntervalData:
         return data[item]
 
     def __setitem__(self, key: slice | tuple | IntervalLike, value):
+        """Assign into ``data`` in place.
+
+        An :py:class:`~genome_kit.Interval` or
+        :py:class:`~genome_kit.DisjointIntervalSequence` key is first resolved to
+        the corresponding slice of the aligned axis; a ``slice`` or tuple is
+        forwarded to ``data`` directly.
+        """
         if isinstance(key, _INTERVAL_LIKE):
             key = self._get_slice(self.interval, self._lift_key(key))
         self.data[key] = value
 
     def __repr__(self):
+        """Return a human-readable representation."""
         return "IntervalData({}, {}, {})".format(
             repr(self.interval), repr(self.data), repr(self.axis)
         )
 
     def __str__(self):
+        """Return the data type together with the interval it is indexed by."""
         return "<{} indexed by <{}>>".format(type(self.data), self.interval)

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -305,9 +305,25 @@ class IntervalData:
         :py:class:`~genome_kit.DisjointIntervalSequence` key is first resolved to
         the corresponding slice of the aligned axis; a ``slice`` or tuple is
         forwarded to ``data`` directly.
+
+        Raises
+        ------
+        IndexError
+            If ``key`` is a plain ``slice`` and the aligned axis is not axis 0.
+            explicitly.
         """
         if isinstance(key, _INTERVAL_LIKE):
-            key = self._get_slice(self.interval, self._lift_key(key))
+            slice_index = self._get_slice(self.interval, self._lift_key(key))
+            if self.axis > 0:
+                slices = self.data.ndim * [slice(None)]
+                slices[self.axis] = slice_index
+                key = tuple(slices)
+            else:
+                key = slice_index
+        elif isinstance(key, slice) and self.axis > 0:
+            raise IndexError(
+                "aligned axis {} requires multidimensional slice.".format(self.axis)
+            )
         self.data[key] = value
 
     def __repr__(self):

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -89,10 +89,10 @@ class IntervalData:
                     len(interval), len(data) if axis == 0 else data.shape[axis]
                 )
             )
-        self.axis = axis
+        self._axis = axis
 
-        self.interval = interval
-        self.data = data
+        self._interval = interval
+        self._data = data
 
     @classmethod
     def from_interval(cls, interval: Interval, data, axis=0) -> "IntervalData":
@@ -127,7 +127,22 @@ class IntervalData:
 
     def __len__(self) -> int:
         """Return the number of aligned positions, i.e. ``len(interval)``."""
-        return len(self.interval)
+        return len(self._interval)
+
+    @property
+    def interval(self) -> IntervalLike:
+        """Return the backing interval-like object."""
+        return self._interval
+
+    @property
+    def data(self):
+        """Return the backing data array."""
+        return self._data
+
+    @property
+    def axis(self) -> int:
+        """Return the axis of ``data`` aligned to ``interval``."""
+        return self._axis
 
     @staticmethod
     def _get_interval(interval: IntervalLike, slice_index: slice) -> IntervalLike:
@@ -222,7 +237,7 @@ class IntervalData:
             If ``key`` is not fully contained within the backing DIS's segment
             (see :py:meth:`~genome_kit.DisjointIntervalSequence.lift_interval`).
         """
-        if isinstance(self.interval, DisjointIntervalSequence) and isinstance(
+        if isinstance(self._interval, DisjointIntervalSequence) and isinstance(
             key, Interval
         ):
             # lift_interval raises ValueError when `key` is not contained in the
@@ -230,12 +245,12 @@ class IntervalData:
             # indexing caller's perspective those are all "key not in this data",
             # so surface an IndexError to match the Interval-backed path.
             try:
-                lifted = self.interval.lift_interval(key)
+                lifted = self._interval.lift_interval(key)
             except ValueError as ex:
                 raise IndexError(str(ex)) from ex
             if lifted is None:
                 raise IndexError(
-                    "interval {} does not contain {}".format(self.interval, key)
+                    "interval {} does not contain {}".format(self._interval, key)
                 )
             return lifted
         return key
@@ -252,25 +267,25 @@ class IntervalData:
         and ``data`` and returns a new :py:class:`IntervalData`. Splicing onto
         the opposite strand reverses ``data``.
         """
-        data = self.data
-        axis = self.axis
+        data = self._data
+        axis = self._axis
 
         if isinstance(item, slice):
             if axis > 0:
                 raise IndexError(
                     "aligned axis {} requires multidimensional slice.".format(axis)
                 )
-            return IntervalData(self._get_interval(self.interval, item), data[item])
+            return IntervalData(self._get_interval(self._interval, item), data[item])
         elif isinstance(item, tuple):
             index = item[axis]
             if isinstance(index, slice):
                 return IntervalData(
-                    self._get_interval(self.interval, index), data[item], axis
+                    self._get_interval(self._interval, index), data[item], axis
                 )
             return data[item]
         elif isinstance(item, _INTERVAL_LIKE):
             item = self._lift_key(item)
-            slice_index = self._get_slice(self.interval, item)
+            slice_index = self._get_slice(self._interval, item)
             if axis > 0:
                 slices = data.ndim * [slice(None)]
                 slices[axis] = slice_index
@@ -293,25 +308,25 @@ class IntervalData:
             explicitly.
         """
         if isinstance(key, _INTERVAL_LIKE):
-            slice_index = self._get_slice(self.interval, self._lift_key(key))
-            if self.axis > 0:
-                slices = self.data.ndim * [slice(None)]
-                slices[self.axis] = slice_index
+            slice_index = self._get_slice(self._interval, self._lift_key(key))
+            if self._axis > 0:
+                slices = self._data.ndim * [slice(None)]
+                slices[self._axis] = slice_index
                 key = tuple(slices)
             else:
                 key = slice_index
-        elif isinstance(key, slice) and self.axis > 0:
+        elif isinstance(key, slice) and self._axis > 0:
             raise IndexError(
-                "aligned axis {} requires multidimensional slice.".format(self.axis)
+                "aligned axis {} requires multidimensional slice.".format(self._axis)
             )
-        self.data[key] = value
+        self._data[key] = value
 
     def __repr__(self):
         """Return a human-readable representation."""
         return "IntervalData({}, {}, {})".format(
-            repr(self.interval), repr(self.data), repr(self.axis)
+            repr(self._interval), repr(self._data), repr(self._axis)
         )
 
     def __str__(self):
         """Return the data type together with the interval it is indexed by."""
-        return "<{} indexed by <{}>>".format(type(self.data), self.interval)
+        return "<{} indexed by <{}>>".format(type(self._data), self._interval)

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -1,0 +1,273 @@
+from .diseq import DisjointIntervalSequence
+from .interval import Interval
+from typing import TypeAlias, Sequence
+
+# Interval-like types IntervalData can be backed by and indexed with. Both present
+# the same 5'->3' coordinate-space interface (__len__, strand, end5.start, expand,
+# as_opposite_strand, contains), so IntervalData stays agnostic to which one it holds.
+_INTERVAL_LIKE = (Interval, DisjointIntervalSequence)
+IntervalLike: TypeAlias = Interval | DisjointIntervalSequence
+
+
+class IntervalData:
+    r"""
+    Associates a data sequence with the genomic interval for convenient splicing.
+
+    Array indexing via [index] will act directly on `data`. Array splicing (via ``slice`` or
+    ``genome_kit.Interval``) will splice both the `interval` and `data`; the associated `data` is assumed to be
+    unstranded 5" to 3", so splicing via the opposite strand will reverse the `data` (similar to tracks).
+
+    References
+    ----------
+    https://deep-genomics-genomekit.readthedocs-hosted.com/en/latest/quickstart.html#tracks
+
+    Examples
+    --------
+    >>> from dgutils.interval import IntervalData
+    >>> import genome_kit as gk
+    >>> import numpy as np
+    >>> interval_len = 500
+    >>> position = gk.Interval('chr7', '+', 100000, 100000, 'hg19')
+    >>> interval = position.expand(0, interval_len)
+    >>> data = np.arange(5 * interval_len * 10).reshape(5, interval_len, 10)
+    >>> interval_data = IntervalData(interval, data, axis=1)
+    >>>
+    >>> # Slicing with __getitem__ is applied to both the interval and data array
+    >>> str(interval_data[:, 100:200, 2:6])
+    '<<type \'numpy.ndarray\'> indexed by <Interval("chr7", "+", 100100, 100200, "hg19")>>'
+    >>>
+    >>> # Slicing with interval reproduces the same results
+    >>> str(interval_data[position.shift(100).expand(0, 100)])
+    '<<type \'numpy.ndarray\'> indexed by <Interval("chr7", "+", 100100, 100200, "hg19")>>'
+    >>>
+    >>> # Indexing with __getitem__ is applied to the data array
+    >>> interval_data[1, 0, 0]
+    5000
+
+    """
+
+    def __init__(self, interval: IntervalLike, data, axis=0):
+        """Initialize an IntervalData.
+
+        Parameters
+        ----------
+        interval : :py:class:`~genome_kit.Interval` or :py:class:`~genome_kit.DisjointIntervalSequence`
+            The genomic interval or disjoint interval(s) of interest.
+
+        data : array_like
+            Must be the same dimension as `interval` and ordered from 5" to 3".
+            If required, `axis` can be used to realign;
+            otherwise, :func:`~numpy.rollaxis` can be used to reindex.
+
+        axis : optional
+            Axis of the multidimensional `data` to align to `interval`. Defaults to 0.
+
+        Raises
+        ------
+        IndexError
+            `axis` cannot be negative
+        ValueError
+            The `data` aligned to the `axis` is not the same dimension as the `interval`.
+        TypeError
+            `interval` is neither an :py:class:`~genome_kit.Interval` nor a
+            :py:class:`~genome_kit.DisjointIntervalSequence`.
+        """
+
+        if not isinstance(interval, _INTERVAL_LIKE):
+            raise TypeError(
+                "interval must be an Interval or DisjointIntervalSequence, got {}.".format(
+                    type(interval).__name__
+                )
+            )
+
+        if axis < 0:
+            raise IndexError("axis {} must be non-negative.".format(axis))
+        if (
+            axis == 0
+            and len(interval) != len(data)
+            or axis > 0
+            and len(interval) != data.shape[axis]
+        ):
+            raise ValueError(
+                "interval ({}) and data ({}) must be of the same rank.".format(
+                    len(interval), len(data)
+                )
+            )
+        self.axis = axis
+
+        self.interval = interval
+        self.data = data
+
+    @classmethod
+    def from_interval(cls, interval: Interval, data, axis=0) -> "IntervalData":
+        """Construct an IntervalData from a single genomic Interval.
+
+        Parameters
+        ----------
+        interval : :py:class:`~genome_kit.Interval`
+            The genomic interval of interest.
+        data : array_like
+            See :py:meth:`__init__`.
+        axis : optional
+            See :py:meth:`__init__`.
+        """
+        return cls(interval, data, axis)
+
+    @classmethod
+    def from_dis(cls, dis: DisjointIntervalSequence, data, axis=0) -> "IntervalData":
+        """Construct an IntervalData from a DisjointIntervalSequence.
+
+        Parameters
+        ----------
+        dis : :py:class:`~genome_kit.DisjointIntervalSequence`
+            The DIS whose segment defines the genomic interval(s).
+        data : array_like
+            See :py:meth:`__init__`.
+        axis : optional
+            See :py:meth:`__init__`.
+
+        """
+        return cls(dis, data, axis)
+
+    @classmethod
+    def from_intervals(
+        cls, intervals: Sequence[Interval], data, axis=0
+    ) -> "IntervalData":
+        """Construct an IntervalData from a sequence of disjoint genomic Intervals.
+
+        The intervals are transformed into a :py:class:`~genome_kit.DisjointIntervalSequence`.
+
+        Parameters
+        ----------
+        intervals : Sequence[:py:class:`~genome_kit.Interval`]
+            Non-overlapping intervals on the same chromosome, strand, and reference genome.
+        data : array_like
+            See :py:meth:`__init__`.
+        axis : optional
+            See :py:meth:`__init__`.
+
+        """
+        return cls(DisjointIntervalSequence.from_intervals(intervals), data, axis)
+
+    def __len__(self) -> int:
+        return len(self.interval)
+
+    @staticmethod
+    def _get_interval(interval: IntervalLike, slice_index: slice) -> IntervalLike:
+        length = len(interval)
+        start, stop, step = slice_index.indices(length)
+        if abs(step) != 1:
+            raise KeyError("discontinuous steps are not supported for intervals.")
+
+        if step > 0:
+            upstream = -start
+            downstream = stop - length
+        else:
+            upstream = -(stop + 1)
+            downstream = start - length + 1
+        interval = interval.expand(upstream, downstream)
+        if step < 0:
+            interval = interval.as_opposite_strand()
+        return interval
+
+    @staticmethod
+    def _get_slice(interval: IntervalLike, interval_slice: IntervalLike) -> slice:
+        if interval_slice.strand == interval.strand:
+            if not interval.contains(interval_slice):
+                raise IndexError(
+                    "interval {} does not contain {}".format(interval, interval_slice)
+                )
+
+            start = abs(interval_slice.end5.start - interval.end5.start)
+            stop = start + len(interval_slice)
+            step = None
+        else:
+            opp_strand = interval_slice.as_opposite_strand()
+            if not interval.contains(opp_strand):
+                raise IndexError(
+                    "interval {} does not contain {}".format(interval, interval_slice)
+                )
+
+            stop = abs(opp_strand.end5.start - interval.end5.start) - 1
+            start = stop + len(opp_strand)
+            if stop < 0:
+                stop = None
+            step = -1
+        return slice(start, stop, step)
+
+    def _lift_key(self, key: IntervalLike) -> IntervalLike:
+        """Normalize an interval-like key into the backing interval's coordinate space.
+
+        When this IntervalData is backed by a
+        :py:class:`~genome_kit.DisjointIntervalSequence` and `key` is a genomic
+        :py:class:`~genome_kit.Interval`, the key is lifted (via
+        :py:meth:`~genome_kit.DisjointIntervalSequence.lift_interval`) so that
+        indexing happens in the DIS's flattened coordinate space. All other cases
+        — an Interval-backed IntervalData, or a key already in the backing
+        coordinate space — pass through unchanged.
+
+        Raises
+        ------
+        IndexError
+            If `key` is not fully contained within the backing DIS's segment
+            (see :py:meth:`~genome_kit.DisjointIntervalSequence.lift_interval`).
+        """
+        if isinstance(self.interval, DisjointIntervalSequence) and isinstance(
+            key, Interval
+        ):
+            # lift_interval raises ValueError when `key` is not contained in the
+            # segment or is on a mismatched chromosome/reference genome. From the
+            # indexing caller's perspective those are all "key not in this data",
+            # so surface an IndexError to match the Interval-backed path.
+            try:
+                lifted = self.interval.lift_interval(key)
+            except ValueError as ex:
+                raise IndexError(str(ex)) from ex
+            if lifted is None:
+                raise IndexError(
+                    "interval {} does not contain {}".format(self.interval, key)
+                )
+            return lifted
+        return key
+
+    def __getitem__(
+        self, item: slice | tuple | int | IntervalLike
+    ) -> "IntervalData" | Sequence:
+        data = self.data
+        axis = self.axis
+
+        if isinstance(item, slice):
+            if axis > 0:
+                raise IndexError(
+                    "aligned axis {} requires multidimensional slice.".format(axis)
+                )
+            return IntervalData(self._get_interval(self.interval, item), data[item])
+        elif isinstance(item, tuple):
+            index = item[axis]
+            if isinstance(index, slice):
+                return IntervalData(
+                    self._get_interval(self.interval, index), data[item], axis
+                )
+            return data[item]
+        elif isinstance(item, _INTERVAL_LIKE):
+            item = self._lift_key(item)
+            slice_index = self._get_slice(self.interval, item)
+            if axis > 0:
+                slices = data.ndim * [slice(None)]
+                slices[axis] = slice_index
+                slice_index = tuple(slices)
+            return IntervalData(item, data[slice_index], axis)
+        return data[item]
+
+    def __setitem__(self, key: slice | tuple | IntervalLike, value):
+        if isinstance(key, _INTERVAL_LIKE):
+            key = self._get_slice(self.interval, self._lift_key(key))
+        self.data[key] = value
+
+    def __repr__(self):
+        return "IntervalData({}, {}, {})".format(
+            repr(self.interval), repr(self.data), repr(self.axis)
+        )
+
+    def __str__(self):
+        return "<{} indexed by <{}>>".format(type(self.data), self.interval)

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -85,8 +85,8 @@ class IntervalData:
             and len(interval) != data.shape[axis]
         ):
             raise ValueError(
-                "interval ({}) and data ({}) must be of the same rank.".format(
-                    len(interval), len(data)
+                "interval ({}) and data axis ({}) must be of the same length.".format(
+                    len(interval), len(data) if axis == 0 else data.shape[axis]
                 )
             )
         self.axis = axis

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -125,26 +125,6 @@ class IntervalData:
         """
         return cls(dis, data, axis)
 
-    @classmethod
-    def from_intervals(
-        cls, intervals: Sequence[Interval], data, axis=0
-    ) -> "IntervalData":
-        """Construct an IntervalData from a sequence of disjoint genomic Intervals.
-
-        The intervals are transformed into a :py:class:`~genome_kit.DisjointIntervalSequence`.
-
-        Parameters
-        ----------
-        intervals
-            Non-overlapping :py:class:`~genome_kit.Interval` objects on the same
-            chromosome, strand, and reference genome.
-        data
-            See :py:meth:`__init__`.
-        axis
-            See :py:meth:`__init__`.
-        """
-        return cls(DisjointIntervalSequence.from_intervals(intervals), data, axis)
-
     def __len__(self) -> int:
         """Return the number of aligned positions, i.e. ``len(interval)``."""
         return len(self.interval)

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -14,20 +14,16 @@ class IntervalData:
     Associates a data sequence with the genomic interval for convenient splicing.
 
     Array indexing via [index] will act directly on `data`. Array splicing (via ``slice`` or
-    ``genome_kit.Interval``) will splice both the `interval` and `data`; the associated `data` is assumed to be
-    unstranded 5" to 3", so splicing via the opposite strand will reverse the `data` (similar to tracks).
-
-    References
-    ----------
-    https://deep-genomics-genomekit.readthedocs-hosted.com/en/latest/quickstart.html#tracks
+    ``Interval`` or ``DisjointIntervalSequence``) will splice both the `interval` and `data`;
+    the associated `data` is assumed to beunstranded 5" to 3", so splicing via the
+    opposite strand will reverse the `data` (similar to tracks).
 
     Examples
     --------
-    >>> from dgutils.interval import IntervalData
-    >>> import genome_kit as gk
+    >>> from genome_kit import Interval, IntervalData
     >>> import numpy as np
     >>> interval_len = 500
-    >>> position = gk.Interval('chr7', '+', 100000, 100000, 'hg19')
+    >>> position = Interval('chr7', '+', 100000, 100000, 'hg19')
     >>> interval = position.expand(0, interval_len)
     >>> data = np.arange(5 * interval_len * 10).reshape(5, interval_len, 10)
     >>> interval_data = IntervalData(interval, data, axis=1)

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -1,6 +1,7 @@
 from .diseq import DisjointIntervalSequence
 from .interval import Interval
 from typing import TypeAlias, Sequence
+import numpy as np
 
 # Interval-like types IntervalData can be backed by and indexed with. Both present
 # the same 5'->3' coordinate-space interface (__len__, strand, end5.start, expand,
@@ -220,6 +221,35 @@ class IntervalData:
             step = -1
         return slice(start, stop, step)
 
+    @staticmethod
+    def _validate_interval_list(items: list) -> None:
+        """Validate a ``list`` key/item of genomic Intervals.
+
+        Every element must be an :py:class:`~genome_kit.Interval`, and no two
+        elements may overlap (a shared boundary, e.g. ``[10, 20)`` and
+        ``[20, 30)``, is fine).
+
+        Raises
+        ------
+        TypeError
+            If any element is not an :py:class:`~genome_kit.Interval`.
+        ValueError
+            If any two elements overlap.
+        """
+        if not all(isinstance(item, Interval) for item in items):
+            raise TypeError("list elements must be Interval.")
+        if len(items) < 2:
+            return
+        if items[0].strand == "+":
+            sorted_items = sorted(items, key=lambda iv: iv.start)
+        else:
+            sorted_items = sorted(items, key=lambda iv: -iv.end)
+        for a, b in zip(sorted_items, sorted_items[1:]):
+            if a.overlaps(b):
+                raise ValueError(
+                    "list elements must not overlap: {} overlaps {}.".format(a, b)
+                )
+
     def _lift_key(self, key: IntervalLike) -> IntervalLike:
         """Normalize an interval-like key into the backing interval's coordinate space.
 
@@ -256,16 +286,17 @@ class IntervalData:
         return key
 
     def __getitem__(
-        self, item: slice | tuple | int | IntervalLike
+        self, item: slice | tuple | int | IntervalLike | list[Interval]
     ) -> "IntervalData" | Sequence:
         """Index the data, or splice both the interval and data together.
 
         An integer (or a tuple whose aligned-axis entry is an integer) indexes
         ``data`` directly and returns the raw array value. A ``slice``, an
-        :py:class:`~genome_kit.Interval`, or a
-        :py:class:`~genome_kit.DisjointIntervalSequence` slices both ``interval``
-        and ``data`` and returns a new :py:class:`IntervalData`. Splicing onto
-        the opposite strand reverses ``data``.
+        :py:class:`~genome_kit.Interval`, a
+        :py:class:`~genome_kit.DisjointIntervalSequence`, or a ``list`` of
+        non-overlapping :py:class:`~genome_kit.Interval` objects slices both
+        ``interval`` and ``data`` and returns a new :py:class:`IntervalData`.
+        Splicing onto the opposite strand reverses ``data``.
         """
         data = self._data
         axis = self._axis
@@ -283,15 +314,40 @@ class IntervalData:
                     self._get_interval(self._interval, index), data[item], axis
                 )
             return data[item]
-        elif isinstance(item, _INTERVAL_LIKE):
-            item = self._lift_key(item)
-            slice_index = self._get_slice(self._interval, item)
-            if axis > 0:
-                slices = data.ndim * [slice(None)]
-                slices[axis] = slice_index
-                slice_index = tuple(slices)
-            return IntervalData(item, data[slice_index], axis)
+        elif isinstance(item, _INTERVAL_LIKE) or isinstance(item, list):
+            return self._get_interval_like(item)
         return data[item]
+
+    def _get_interval_like(self, item: IntervalLike | list[Interval]) -> "IntervalData":
+        """Return the sub-``IntervalData`` selected by an interval-like item.
+
+        If ``item`` is a :py:class:`~genome_kit.DisjointIntervalSequence` or ``List``,
+        the multi-region data returned from this IntervalData is
+        concatenated along the aligned axis, in 5'->3' order.
+
+        Raises
+        ------
+        TypeError
+            If ``item`` is a ``list`` containing an element that is not an
+            :py:class:`~genome_kit.Interval`.
+        ValueError
+            If ``item`` is a ``list`` containing two overlapping Intervals.
+        """
+        if isinstance(item, list):
+            self._validate_interval_list(item)
+            dis = DisjointIntervalSequence.from_intervals(item)
+            return IntervalData(dis, self._concat_pieces(dis.lower()), self._axis)
+
+        if isinstance(self._interval, Interval) and isinstance(item, DisjointIntervalSequence):
+            return IntervalData(item, self._concat_pieces(item.lower()), self._axis)
+
+        lifted = self._lift_key(item)
+        slice_index = self._get_slice(self._interval, lifted)
+        if self._axis > 0:
+            slices = self._data.ndim * [slice(None)]
+            slices[self._axis] = slice_index
+            slice_index = tuple(slices)
+        return IntervalData(lifted, self._data[slice_index], self._axis)
 
     def __setitem__(self, key: slice | tuple | IntervalLike, value):
         """Assign into ``data`` in place.

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -31,11 +31,11 @@ class IntervalData:
     >>>
     >>> # Slicing with __getitem__ is applied to both the interval and data array
     >>> str(interval_data[:, 100:200, 2:6])
-    '<<type \'numpy.ndarray\'> indexed by <Interval("chr7", "+", 100100, 100200, "hg19")>>'
+    '<<class \'numpy.ndarray\'> indexed by <Interval("chr7", "+", 100100, 100200, "hg19")>>'
     >>>
     >>> # Slicing with interval reproduces the same results
     >>> str(interval_data[position.shift(100).expand(0, 100)])
-    '<<type \'numpy.ndarray\'> indexed by <Interval("chr7", "+", 100100, 100200, "hg19")>>'
+    '<<class \'numpy.ndarray\'> indexed by <Interval("chr7", "+", 100100, 100200, "hg19")>>'
     >>>
     >>> # Indexing with __getitem__ is applied to the data array
     >>> interval_data[1, 0, 0]
@@ -349,29 +349,194 @@ class IntervalData:
             slice_index = tuple(slices)
         return IntervalData(lifted, self._data[slice_index], self._axis)
 
-    def __setitem__(self, key: slice | tuple | IntervalLike, value):
+    def _concat_pieces(self, intervals: list[Interval]):
+        """Fetch and concatenate the data slices for ``intervals`` (in order)
+        along the aligned axis.
+        """
+        pieces = [self._get_interval_like(iv).data for iv in intervals]
+        return pieces[0] if len(pieces) == 1 else np.concatenate(pieces, axis=self._axis)
+
+    # The forms a value assigned via an interval-like key may take. See
+    # :py:meth:`_resolve_value_form`.
+    _SCALAR = "scalar"
+    _BLOCK = "block"
+    _POSITION = "position"
+
+    def _data_shape(self) -> tuple:
+        return self._data.shape if hasattr(self._data, "shape") else np.shape(self._data)
+
+    @staticmethod
+    def _value_shape(value) -> tuple | None:
+        """Return ``value``'s shape, or ``None`` if it has no well-defined one
+        (e.g. a ragged nested ``list``).
+        """
+        if hasattr(value, "shape"):
+            return value.shape
+        try:
+            return np.shape(value)
+        except ValueError:
+            return None
+
+    def _resolve_value_form(self, value, total: int) -> str:
+        """Classify ``value`` against the ``total`` aligned positions selected by
+        an interval-like key.
+
+        Exactly three forms are accepted, chosen so that which axis of ``value``
+        is the aligned one is never ambiguous — ``value``'s rank pins it down:
+
+        ``"block"``
+            ``value`` has ``data``'s shape with the aligned axis resized to
+            ``total``, i.e. the shape :py:meth:`__getitem__` returns for the same
+            key. Supplies one value per selected position.
+        ``"position"``
+            ``value`` has ``data``'s shape with the aligned axis removed. Describes
+            a single position, and is broadcast to every selected one.
+        ``"scalar"``
+            ``value`` has no shape at all, and is broadcast to everything.
+
+        A value that would otherwise reach the aligned axis only through NumPy's
+        right-aligned broadcasting is rejected, since the axis it lands on depends
+        on its rank rather than on the caller's intent.
+
+        Raises
+        ------
+        ValueError
+            If ``value`` matches none of the three forms.
+        """
+        shape = self._value_shape(value)
+        if shape == ():
+            return self._SCALAR
+        data_shape = self._data_shape()
+        block = data_shape[: self._axis] + (total,) + data_shape[self._axis + 1 :]
+        position = data_shape[: self._axis] + data_shape[self._axis + 1 :]
+        if shape == block:
+            return self._BLOCK
+        if shape == position:
+            return self._POSITION
+        raise ValueError(
+            f"value shape {shape if shape is not None else 'unknown'} does not fit "
+            f"{total} aligned position(s): expected {block} (one value per position), "
+            f"{position} (one value broadcast to every position), or a scalar."
+        )
+
+    def _normalize_to_backing_coord(self, key: IntervalLike | list[Interval]) -> list[IntervalLike]:
+        """Resolve an interval-like key into the region(s) of the aligned axis it
+        selects, each normalized into the backing coordinate space and ordered
+        5'->3'.
+
+        A ``list`` key is normalized through a
+        :py:class:`~genome_kit.DisjointIntervalSequence`, so its elements come back
+        merged where adjacent and in 5'->3' order
+
+        Raises
+        ------
+        TypeError
+            If ``key`` is a ``list`` containing an element that is not an
+            :py:class:`~genome_kit.Interval`.
+        ValueError
+            If ``key`` is an empty ``list``, or a ``list`` containing two
+            overlapping Intervals.
+        IndexError
+            If ``key`` is not contained within the backing interval.
+        """
+        if isinstance(key, list):
+            self._validate_interval_list(key)
+            key = DisjointIntervalSequence.from_intervals(key)
+            return [self._lift_key(iv) for iv in key.lower()]
+        if isinstance(key, DisjointIntervalSequence) and isinstance(self._interval, Interval):
+            return [self._lift_key(iv) for iv in key.lower()]
+        return [self._lift_key(key)]
+
+    def _set_interval_like(self, key: IntervalLike | list[Interval], value) -> None:
+        """Assign ``value`` into ``data`` at the aligned-axis region(s) selected by
+        an interval-like key.
+
+        A ``"block"`` value is split along the aligned axis, one chunk per selected
+        region in 5'->3' order; the other forms are broadcast to every region.
+
+        Raises
+        ------
+        TypeError
+            If ``key`` is a ``list`` containing an element that is not an
+            :py:class:`~genome_kit.Interval`.
+        ValueError
+            If ``key`` is an empty ``list`` or contains overlapping Intervals, or if
+            ``value`` matches none of the accepted forms.
+        IndexError
+            If ``key`` is not contained within the backing interval.
+        """
+        keys = self._normalize_to_backing_coord(key)
+        lengths = [len(interval) for interval in keys]
+        form = self._resolve_value_form(value, sum(lengths))
+
+        if form == self._BLOCK:
+            offset = 0
+            for interval, length in zip(keys, lengths):
+                self._set_slice(interval, self._slice_axis(value, offset, offset + length))
+                offset += length
+            return
+        if form == self._POSITION:
+            # Re-insert the aligned axis so NumPy broadcasts `value` along it;
+            # left as-is it would right-align onto the trailing axes instead.
+            value = np.expand_dims(value, self._axis)
+        for interval in keys:
+            self._set_slice(interval, value)
+
+    def _set_slice(self, key: IntervalLike, value) -> None:
+        """Assign ``value`` into ``data`` at the aligned-axis slice selected by a
+        single ``key`` already normalized into the backing coordinate space.
+        """
+        slice_index = self._get_slice(self._interval, key)
+        if self._axis > 0:
+            slices = len(self._data_shape()) * [slice(None)]
+            slices[self._axis] = slice_index
+            slice_index = tuple(slices)
+        self._data[slice_index] = value
+
+    def _slice_axis(self, value, start: int, stop: int):
+        """Return ``value`` sliced to ``[start:stop)`` along the aligned axis
+        of this IntervalData.
+        """
+        if hasattr(value, "shape"):
+            slices = value.ndim * [slice(None)]
+            slices[self._axis] = slice(start, stop)
+            return value[tuple(slices)]
+        return value[start:stop]
+
+    def __setitem__(self, key: slice | tuple | IntervalLike | list[Interval], value):
         """Assign into ``data`` in place.
 
-        An :py:class:`~genome_kit.Interval` or
-        :py:class:`~genome_kit.DisjointIntervalSequence` key is first resolved to
-        the corresponding slice of the aligned axis; a ``slice`` or tuple is
-        forwarded to ``data`` directly.
+        An :py:class:`~genome_kit.Interval`, a
+        :py:class:`~genome_kit.DisjointIntervalSequence`, or a ``list`` of
+        non-overlapping :py:class:`~genome_kit.Interval` objects is resolved
+        to the corresponding region(s) of the aligned axis;
+        a ``slice`` or tuple is forwarded to ``data`` directly.
+
+        For an interval-like ``key``, ``value`` must take one of three forms
+        (see :py:meth:`_resolve_value_form`): ``data``'s shape with the aligned
+        axis resized to the key's length, supplying one value per selected
+        position; ``data``'s shape with the aligned axis removed, describing a
+        single position to broadcast to every selected one; or a scalar. Shapes
+        that would reach the aligned axis only via NumPy's right-aligned
+        broadcasting — including ones padded with length-1 axes — are rejected.
 
         Raises
         ------
         IndexError
-            If ``key`` is a plain ``slice`` and the aligned axis is not axis 0.
-            explicitly.
+            If ``key`` is a plain ``slice`` and the aligned axis is not axis 0,
+            or if an interval-like ``key`` is not contained within ``interval``.
+        TypeError
+            If ``key`` is a ``list`` containing an element that is not an
+            :py:class:`~genome_kit.Interval`.
+        ValueError
+            If ``key`` is an empty ``list`` or a ``list`` containing two
+            overlapping Intervals, or if ``value`` matches none of the accepted
+            forms.
         """
-        if isinstance(key, _INTERVAL_LIKE):
-            slice_index = self._get_slice(self._interval, self._lift_key(key))
-            if self._axis > 0:
-                slices = self._data.ndim * [slice(None)]
-                slices[self._axis] = slice_index
-                key = tuple(slices)
-            else:
-                key = slice_index
-        elif isinstance(key, slice) and self._axis > 0:
+        if isinstance(key, _INTERVAL_LIKE) or isinstance(key, list):
+            self._set_interval_like(key, value)
+            return
+        if isinstance(key, slice) and self._axis > 0:
             raise IndexError(
                 "aligned axis {} requires multidimensional slice.".format(self._axis)
             )

--- a/genome_kit/interval_data.py
+++ b/genome_kit/interval_data.py
@@ -512,6 +512,9 @@ class IntervalData:
         to the corresponding region(s) of the aligned axis;
         a ``slice`` or tuple is forwarded to ``data`` directly.
 
+        If setting via an Interval-like key, the key must be fully contained within
+        the backing interval.
+
         For an interval-like ``key``, ``value`` must take one of three forms
         (see :py:meth:`_resolve_value_form`): ``data``'s shape with the aligned
         axis resized to the key's length, supplying one value per selected

--- a/tests/test_diseq.py
+++ b/tests/test_diseq.py
@@ -894,6 +894,74 @@ class TestShift(unittest.TestCase):
         self.assertEqual(shifted.end, 140)
 
 
+class TestCut(unittest.TestCase):
+
+    def test_cut_sets_indices(self):
+        dis = _dis(start=30, end=150)
+        cut = dis.cut(40, 120)
+        self.assertEqual(cut.start, 40)
+        self.assertEqual(cut.end, 120)
+
+    def test_cut_full_coordinate_space(self):
+        dis = _dis(start=30, end=150)
+        cut = dis.cut(0, dis.coordinate_length)
+        self.assertEqual(cut.start, 0)
+        self.assertEqual(cut.end, 200)
+
+    def test_cut_zero_length(self):
+        dis = _dis(start=30, end=150)
+        cut = dis.cut(80, 80)
+        self.assertEqual(cut.start, 80)
+        self.assertEqual(cut.end, 80)
+        self.assertEqual(cut.length, 0)
+
+    def test_cut_extrapolated_indices(self):
+        # Indices outside [0, coordinate_length] represent flanking positions.
+        dis = _dis(start=30, end=150)
+        cut = dis.cut(-20, 210)
+        self.assertEqual(cut.start, -20)
+        self.assertEqual(cut.end, 210)
+
+    def test_cut_start_greater_than_end_raises(self):
+        dis = _dis(start=30, end=150)
+        with self.assertRaises(ValueError):
+            dis.cut(120, 40)
+
+    def test_cut_preserves_coordinate_space(self):
+        dis = _dis(start=30, end=150)
+        cut = dis.cut(40, 120)
+        self.assertEqual(cut.coordinate_intervals, dis.coordinate_intervals)
+
+    def test_cut_preserves_metadata(self):
+        dis = _dis(start=30, end=150, coord_name="mycoord", segment_name="myiv")
+        cut = dis.cut(40, 120)
+        self.assertEqual(cut.coord_name, "mycoord")
+        self.assertEqual(cut.name, "myiv")
+        self.assertTrue(cut.on_coordinate_strand)
+
+    def test_cut_preserves_opposite_strand(self):
+        dis = _dis(start=30, end=150, on_coordinate_strand=False)
+        cut = dis.cut(40, 120)
+        self.assertEqual(cut.start, 40)
+        self.assertEqual(cut.end, 120)
+        self.assertFalse(cut.on_coordinate_strand)
+
+    def test_cut_negative_strand_coords(self):
+        # start/end are absolute coord-space indices regardless of genomic strand.
+        dis = _neg_dis(start=30, end=150)
+        cut = dis.cut(40, 120)
+        self.assertEqual(cut.start, 40)
+        self.assertEqual(cut.end, 120)
+
+    def test_cut_negative_strand_coords_segment_opposite_strand_flanking(self):
+        # start/end are absolute coord-space indices regardless of genomic strand.
+        dis = _neg_dis(start=30, end=150, on_coordinate_strand=False)
+        cut = dis.cut(-40, -20)
+        self.assertEqual(cut.start, -40)
+        self.assertEqual(cut.end, -20)
+        self.assertFalse(cut.on_coordinate_strand)
+
+
 class TestExpand(unittest.TestCase):
 
     def test_expand_symmetric(self):

--- a/tests/test_diseq.py
+++ b/tests/test_diseq.py
@@ -2035,7 +2035,7 @@ class TestLiftInterval(unittest.TestCase):
     def test_plus_partial_overlap(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
         dis = DisjointIntervalSequence(ivs, start=0, end=50)
-        lifted = dis.lift_interval(Interval("chr1", "+", 130, 170, REFG))
+        lifted = dis.lift_interval(Interval("chr1", "+", 130, 170, REFG), intersect_on_lift=True)
         self.assertIsNotNone(lifted)
         self.assertEqual(lifted.start, 30)
         self.assertEqual(lifted.end, 50)
@@ -2044,13 +2044,13 @@ class TestLiftInterval(unittest.TestCase):
     def test_no_overlap_returns_none(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
         dis = DisjointIntervalSequence(ivs, start=0, end=50)
-        lifted = dis.lift_interval(Interval("chr1", "+", 320, 360, REFG))
+        lifted = dis.lift_interval(Interval("chr1", "+", 320, 360, REFG), intersect_on_lift=True)
         self.assertIsNone(lifted)
 
     def test_lift_in_coord_gap_returns_none(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
         dis = DisjointIntervalSequence(ivs, start=0, end=200)
-        lifted = dis.lift_interval(Interval("chr1", "+", 250, 260, REFG))
+        lifted = dis.lift_interval(Interval("chr1", "+", 250, 260, REFG), intersect_on_lift=True)
         self.assertIsNone(lifted)
 
     def test_minus_coord(self):
@@ -2137,7 +2137,7 @@ class TestLiftInterval(unittest.TestCase):
     def test_lift_upstream_of_coord_plus(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
         dis = DisjointIntervalSequence(ivs, start=-50, end=200)
-        lifted = dis.lift_interval(Interval("chr1", "+", 70, 90, REFG))
+        lifted = dis.lift_interval(Interval("chr1", "+", 70, 90, REFG), intersect_on_lift=True)
         self.assertIsNotNone(lifted)
         self.assertEqual(lifted.start, -30)
         self.assertEqual(lifted.end, -10)
@@ -2164,7 +2164,7 @@ class TestLiftInterval(unittest.TestCase):
     def test_lift_outside_segment_returns_none(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
         dis = DisjointIntervalSequence(ivs, start=0, end=200)
-        lifted = dis.lift_interval(Interval("chr1", "+", 70, 90, REFG))
+        lifted = dis.lift_interval(Interval("chr1", "+", 70, 90, REFG), intersect_on_lift=True)
         self.assertIsNone(lifted)
 
     def test_lift_upstream_of_coord_minus(self):
@@ -2190,11 +2190,65 @@ class TestLiftInterval(unittest.TestCase):
         dis = DisjointIntervalSequence(
             ivs, start=-40, end=240, on_coordinate_strand=False,
         )
-        lifted = dis.lift_interval(Interval("chr1", "+", 50, 450, REFG))
+        lifted = dis.lift_interval(Interval("chr1", "+", 50, 450, REFG), intersect_on_lift=True)
         self.assertIsNotNone(lifted)
         self.assertEqual(lifted.start, -40)
         self.assertEqual(lifted.end, 240)
         self.assertFalse(lifted.on_coordinate_strand)
+
+    def test_plus_partial_overlap_raises_without_intersect(self):
+        # Interval straddles the segment's 3' edge: not fully contained, so
+        # lifting without intersect_on_lift must raise.
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=50)
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(Interval("chr1", "+", 130, 170, REFG))
+
+    def test_no_overlap_raises_without_intersect(self):
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=50)
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(Interval("chr1", "+", 320, 360, REFG))
+
+    def test_lift_in_coord_gap_raises_without_intersect(self):
+        # Interval falls in the gap between coord intervals.
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=200)
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(Interval("chr1", "+", 250, 260, REFG))
+
+    def test_lift_spanning_coord_gap_raises_without_intersect(self):
+        # Both endpoints land inside the segment, but the interval spans the
+        # gap between the two coord intervals, so it is not contained in any
+        # single lowered interval.
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=200)
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(Interval("chr1", "+", 150, 350, REFG))
+
+    def test_lift_outside_segment_raises_without_intersect(self):
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=200)
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(Interval("chr1", "+", 70, 90, REFG))
+
+    def test_lift_upstream_of_coord_plus_raises_without_intersect(self):
+        # Segment extends upstream of the coord 5' edge but does not reach the
+        # interval, leaving it outside the segment's bases.
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=-50, end=200)
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(Interval("chr1", "+", 20, 40, REFG))
+
+    def test_lift_minus_coord_off_strand_full_span_raises_without_intersect(self):
+        # Opposite-strand interval spans the full coord plus flanks; it crosses
+        # the coord gap and so is not contained in any single lowered interval.
+        ivs = _make_intervals([("chr1", "-", 100, 200), ("chr1", "-", 300, 400)])
+        dis = DisjointIntervalSequence(
+            ivs, start=-40, end=240, on_coordinate_strand=False,
+        )
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(Interval("chr1", "+", 50, 450, REFG))
 
     def test_lift_idempotency(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])

--- a/tests/test_diseq.py
+++ b/tests/test_diseq.py
@@ -2110,6 +2110,15 @@ class TestLiftInterval(unittest.TestCase):
         self.assertEqual(lifted.end, 50)
         self.assertTrue(lifted.on_coordinate_strand)
 
+    def test_interval_partially_in_gap(self):
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=200)
+        lifted = dis.lift_interval(Interval("chr1", "+", 150, 250, REFG), intersect_on_lift=True)
+        self.assertIsNotNone(lifted)
+        self.assertEqual(lifted.start, 50)
+        self.assertEqual(lifted.end, 100)
+        self.assertTrue(lifted.on_coordinate_strand)
+
     def test_no_overlap_returns_none(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
         dis = DisjointIntervalSequence(ivs, start=0, end=50)

--- a/tests/test_diseq.py
+++ b/tests/test_diseq.py
@@ -399,15 +399,15 @@ class TestProperties(unittest.TestCase):
 
 class TestStrandMethods(unittest.TestCase):
 
-    def test_is_same_strand_true(self):
+    def test_is_on_coordinate_strand_true(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, on_coordinate_strand=True)
-        self.assertTrue(dis.is_same_strand())
+        self.assertTrue(dis.is_on_coordinate_strand())
 
-    def test_is_same_strand_false(self):
+    def test_is_on_coordinate_strand_false(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, on_coordinate_strand=False)
-        self.assertFalse(dis.is_same_strand())
+        self.assertFalse(dis.is_on_coordinate_strand())
 
     def test_is_positive_strand_plus_on_coord(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
@@ -469,87 +469,88 @@ class TestStrandMethods(unittest.TestCase):
         self.assertEqual(result.end, 80)
         self.assertEqual(result, expected)
 
-    def test_flip_strand(self):
+    def test_as_opposite_strand(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, on_coordinate_strand=True)
-        flipped = dis.flip_strand()
+        flipped = dis.as_opposite_strand()
         self.assertFalse(flipped.on_coordinate_strand)
-        flipped2 = flipped.flip_strand()
+        flipped2 = flipped.as_opposite_strand()
         self.assertTrue(flipped2.on_coordinate_strand)
 
-    def test_flip_strand_preserves_coordinate_intervals(self):
+    def test_as_opposite_strand_preserves_coordinate_intervals(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
         dis = DisjointIntervalSequence(ivs)
-        flipped = dis.flip_strand()
+        flipped = dis.as_opposite_strand()
         self.assertEqual(flipped.coordinate_intervals, dis.coordinate_intervals)
 
-    def test_flip_strand_preserves_start_end(self):
+    def test_as_opposite_strand_preserves_start_end(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, start=10, end=80)
-        flipped = dis.flip_strand()
+        flipped = dis.as_opposite_strand()
         self.assertEqual(flipped.start, 10)
         self.assertEqual(flipped.end, 80)
 
-    def test_flip_strand_preserves_metadata(self):
+    def test_as_opposite_strand_preserves_metadata(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, coord_name="c", segment_name="i")
-        flipped = dis.flip_strand()
+        flipped = dis.as_opposite_strand()
         self.assertEqual(flipped.coord_name, "c")
         self.assertEqual(flipped.name, "i")
 
-    def test_end5_end3_swap_on_flip_strand(self):
+    def test_end5_end3_swap_on_as_opposite_strand(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, start=10, end=80)
         # On coordinate strand: end5 at start, end3 at end
         self.assertEqual(dis.end5_index, 10)
         self.assertEqual(dis.end3_index, 80)
         # Flipped: end5 at end, end3 at start
-        flipped = dis.flip_strand()
+        flipped = dis.as_opposite_strand()
         self.assertEqual(flipped.end5_index, 80)
         self.assertEqual(flipped.end3_index, 10)
 
-    def test_as_opposite_strand_already_opposite(self):
+    def test_as_off_coordinate_strand_already_off(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, on_coordinate_strand=False)
-        result = dis.as_opposite_strand()
+        result = dis.as_off_coordinate_strand()
         self.assertIs(result, dis)
 
-    def test_as_opposite_strand_from_same(self):
+    def test_as_off_coordinate_strand_from_on(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, on_coordinate_strand=True, start=10, end=80)
-        result = dis.as_opposite_strand()
+        result = dis.as_off_coordinate_strand()
         self.assertFalse(result.on_coordinate_strand)
         self.assertEqual(result.start, 10)
         self.assertEqual(result.end, 80)
 
-    def test_as_opposite_strand_preserves_metadata(self):
+    def test_as_off_coordinate_strand_preserves_metadata(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, coord_name="c", segment_name="i")
-        opp = dis.as_opposite_strand()
-        self.assertEqual(opp.coord_name, "c")
-        self.assertEqual(opp.name, "i")
+        off = dis.as_off_coordinate_strand()
+        self.assertEqual(off.coord_name, "c")
+        self.assertEqual(off.name, "i")
 
-    def test_as_same_strand_already_same(self):
+    def test_as_on_coordinate_strand_already_on(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, on_coordinate_strand=True)
-        result = dis.as_same_strand()
+        result = dis.as_on_coordinate_strand()
         self.assertIs(result, dis)
 
-    def test_as_same_strand_flips(self):
+    def test_as_on_coordinate_strand_flips(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, on_coordinate_strand=False, start=10, end=80)
-        result = dis.as_same_strand()
+        result = dis.as_on_coordinate_strand()
         self.assertTrue(result.on_coordinate_strand)
         self.assertEqual(result.start, 10)
         self.assertEqual(result.end, 80)
 
     def test_idempotency(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
-        dis_pos = DisjointIntervalSequence(ivs, on_coordinate_strand=True)
-        self.assertIs(dis_pos.as_positive_strand().as_positive_strand(), dis_pos)
-        self.assertIs(dis_pos.as_same_strand().as_same_strand(), dis_pos)
-        dis_opp = DisjointIntervalSequence(ivs, on_coordinate_strand=False)
-        self.assertIs(dis_opp.as_opposite_strand().as_opposite_strand(), dis_opp)
+        dis_on = DisjointIntervalSequence(ivs, on_coordinate_strand=True)
+        self.assertIs(dis_on.as_positive_strand().as_positive_strand(), dis_on)
+        self.assertIs(dis_on.as_on_coordinate_strand().as_on_coordinate_strand(), dis_on)
+        dis_off = DisjointIntervalSequence(ivs, on_coordinate_strand=False)
+        self.assertIs(dis_off.as_off_coordinate_strand().as_off_coordinate_strand(), dis_off)
+        self.assertEqual(dis_off.as_opposite_strand().as_opposite_strand(), dis_off)
 
     def test_as_positive_strand_preserves_start_end(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
@@ -2121,6 +2122,24 @@ class TestLiftInterval(unittest.TestCase):
         lifted = dis.lift_interval(Interval("chr1", "+", 250, 260, REFG), intersect_on_lift=True)
         self.assertIsNone(lifted)
 
+    def test_lift_interval_filling_coord_gap(self):
+        # A (non-zero-length) interval that exactly fills the coord gap (genomic
+        # 200..300), touching iv1's 3' end and iv2's 5' start. The gap contributes
+        # no bases to the spliced sequence, so with intersect_on_lift the interval
+        # collapses to a zero-length segment at the junction index (100). Without
+        # intersect_on_lift the interval is not contained in the segment's bases,
+        # so lifting raises.
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=200)
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(Interval("chr1", "+", 200, 300, REFG))
+        lifted = dis.lift_interval(Interval("chr1", "+", 200, 300, REFG), intersect_on_lift=True)
+        self.assertIsNotNone(lifted)
+        self.assertEqual(lifted.start, 100)
+        self.assertEqual(lifted.end, 100)
+        self.assertEqual(len(lifted), 0)
+        self.assertTrue(lifted.on_coordinate_strand)
+
     def test_minus_coord(self):
         ivs = _make_intervals([("chr1", "-", 100, 200), ("chr1", "-", 300, 400)])
         dis = DisjointIntervalSequence(ivs, start=0, end=200)
@@ -2196,11 +2215,80 @@ class TestLiftInterval(unittest.TestCase):
         self.assertEqual(lifted.coord_name, "cs")
         self.assertIsNone(lifted.name)
 
-    def test_zero_length_interval_returns_none(self):
+    def test_zero_length_interval(self):
         ivs = _make_intervals([("chr1", "+", 100, 200)])
         dis = DisjointIntervalSequence(ivs, start=0, end=100)
         lifted = dis.lift_interval(Interval("chr1", "+", 150, 150, REFG))
-        self.assertIsNone(lifted)
+        self.assertIsNotNone(lifted)
+        self.assertEqual(lifted.start, 50)
+        self.assertEqual(lifted.end, 50)
+        self.assertTrue(lifted.on_coordinate_strand)
+
+    def _assert_zero_len_lift_contained(self, dis, iv_strand, pos, exp_pos):
+        iv = Interval("chr1", iv_strand, pos, pos, REFG)
+        intersect_lift = dis.lift_interval(iv, intersect_on_lift=False)
+        no_intersect_lift = dis.lift_interval(iv, intersect_on_lift=True)
+        # intersect_on_lift makes no difference for a contained zero-length key.
+        self.assertEqual(intersect_lift, no_intersect_lift)
+        for lifted in (intersect_lift, no_intersect_lift):
+            self.assertIsNotNone(lifted)
+            self.assertEqual(len(lifted), 0)
+            self.assertEqual(lifted.start, exp_pos)
+            self.assertEqual(lifted.end, exp_pos)
+
+    def _assert_zero_len_lift_outside(self, dis, iv_strand, pos):
+        iv = Interval("chr1", iv_strand, pos, pos, REFG)
+        # Off the segment's bases the flag matters: without intersect the lift
+        # raises; with intersect it clips to nothing and returns None.
+        with self.assertRaisesRegex(ValueError, "intersect_on_lift=True"):
+            dis.lift_interval(iv, intersect_on_lift=False)
+        self.assertIsNone(dis.lift_interval(iv, intersect_on_lift=True))
+
+    def test_zero_length_lift_plus_coord(self):
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=200)
+        for test_name, genomic_pos, dis_pos in [
+            ("within an interval", 150, 50),
+            ("touching the start boundary", 100, 0),
+            ("touching an internal boundary (iv1 3' end)", 200, 100),
+            ("touching an internal boundary (iv2 5' start)", 300, 100),
+            ("touching the end boundary", 400, 200),
+        ]:
+            with self.subTest(case=test_name):
+                self._assert_zero_len_lift_contained(dis, "+", genomic_pos, dis_pos)
+        for test_name, genomic_pos in [
+            ("completely off, upstream", 50),
+            ("completely off, downstream", 450),
+            ("within an interval gap", 250),
+        ]:
+            with self.subTest(case=test_name):
+                self._assert_zero_len_lift_outside(dis, "+", genomic_pos)
+
+    def test_zero_length_lift_minus_coord(self):
+        ivs = _make_intervals([("chr1", "-", 100, 200), ("chr1", "-", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=0, end=200)
+        for test_name, genomic_pos, dis_pos in [
+            ("within an interval", 350, 50),
+            ("touching the start boundary", 400, 0),
+            ("touching an internal boundary (iv1 3' end)", 300, 100),
+            ("touching an internal boundary (iv2 5' start)", 200, 100),
+            ("touching the end boundary", 100, 200),
+        ]:
+            with self.subTest(case=test_name):
+                self._assert_zero_len_lift_contained(dis, "-", genomic_pos, dis_pos)
+        for test_name, genomic_pos in [
+            ("completely off, upstream (5')", 450),
+            ("completely off, downstream (3')", 50),
+            ("within an interval gap", 250),
+        ]:
+            with self.subTest(case=test_name):
+                self._assert_zero_len_lift_outside(dis, "-", genomic_pos)
+
+    def test_zero_length_lift_at_segment_boundary(self):
+        ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])
+        dis = DisjointIntervalSequence(ivs, start=30, end=50)
+        self._assert_zero_len_lift_contained(dis, "+", 130, 30)
+        self._assert_zero_len_lift_contained(dis, "+", 150, 50)
 
     def test_lift_upstream_of_coord_plus(self):
         ivs = _make_intervals([("chr1", "+", 100, 200), ("chr1", "+", 300, 400)])

--- a/tests/test_interval_data.py
+++ b/tests/test_interval_data.py
@@ -1,0 +1,611 @@
+from copy import deepcopy
+from genome_kit import Genome, Interval, IntervalData
+from genome_kit.diseq import DisjointIntervalSequence
+from tests import MiniGenome
+import numpy as np
+import unittest
+
+nucleotide_complement = str.maketrans('ACGT', 'TGCA')
+REFG = "hg19.mini"
+
+
+def _make_intervals(specs, refg=REFG):
+    """Build Intervals from a list of ``(chrom, strand, start, end)`` specs."""
+    return [
+        Interval(chrom, strand, start, end, refg) for chrom, strand, start, end in specs
+    ]
+
+
+def _dis_cases(length):
+    """Return ``(label, dis)`` pairs realizing a ``length``-base segment in
+    several :py:class:`~genome_kit.DisjointIntervalSequence` configurations.
+    """
+    cases = []
+    for strand in ("+", "-"):
+        # Contiguous segment interior to a single coord interval, with room to
+        # expand/contract on both sides.
+        single = _make_intervals([("chr1", strand, 100, 200)])
+        cases.append(
+            (
+                f"single_{strand}_coord_iv",
+                DisjointIntervalSequence(single, start=50, end=50 + length),
+            )
+        )
+        cases.append(
+            (
+                f"single_{strand}_coord_iv_dis_off_coord_strand",
+                DisjointIntervalSequence(single, start=50, end=50 + length, on_coordinate_strand=False),
+            )
+        )
+    if length >= 2:
+        for strand in ("+", "-"):
+            # Two coord intervals with a gap. The first is 10 bases, so a segment
+            # starting at index 9 straddles the internal boundary at index 10.
+            double_coord_iv = _make_intervals(
+                [("chr1", strand, 100, 110), ("chr1", strand, 200, 210)]
+            )
+            cases.append(
+                (
+                    f"spans_2_{strand}_coord_ivs",
+                    DisjointIntervalSequence(double_coord_iv, start=9, end=9 + length),
+                )
+            )
+    return cases
+
+
+def _slice_index_cases(rank):
+    """Slice-index cases exercised by the ``[start:stop:step]`` tests."""
+    return [('empty', dict(start=0, stop=0)),
+            ('none', dict()),
+            ('full', dict(start=0, stop=rank, step=1)),
+            ('stop_full', dict(stop=rank)),
+            ('stop_middle', dict(stop=1)),
+            ('stop_after_range', dict(stop=rank * 2)),
+            ('stop_negative', dict(stop=-1)),
+            ('stop_negative_before_range', dict(stop=-(rank * 2))),
+            ('start_full', dict(start=0)),
+            ('start_middle', dict(start=1)),
+            ('start_after_range', dict(start=rank * 2)),
+            ('start_negative', dict(start=-1)),
+            ('start_negative_before_range', dict(start=-(rank * 2))),
+            ('step_forward', dict(step=1)),
+            ('step_reverse', dict(step=-1)),
+            ('step_discontinuous', dict(step=2, throws=True)),
+            ('reverse_segment', dict(start=1, step=-1)),
+            ('reverse_negative_segment', dict(start=-1, stop=1, step=-1)),
+            ('reverse_outside_range', dict(start=rank * 2, stop=-(rank * 2), step=-1))]
+
+
+class TestIntervalData(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.genome = MiniGenome(REFG)
+
+    def test_same_dimension(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(3, 10)
+        interval_data = IntervalData(interval, data)
+        self.assertEqual(len(interval), len(interval_data))
+        self.assertEqual(interval, interval_data.interval)
+        np.testing.assert_equal(data, [x for x in interval_data])
+
+    def test_same_dimension_dis(self):
+        data = np.arange(0, 30).reshape(3, 10)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                self.assertEqual(len(dis), len(interval_data))
+                self.assertEqual(dis, interval_data.interval)
+                np.testing.assert_equal(data, [x for x in interval_data])
+
+    def test_empty(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval_data = IntervalData(position, [])
+        self.assertEqual(0, len(interval_data))
+        self.assertEqual(0, len([x for x in interval_data]))
+
+    def test_empty_dis(self):
+        for name, dis in _dis_cases(0):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, [])
+                self.assertEqual(0, len(interval_data))
+                self.assertEqual(0, len([x for x in interval_data]))
+
+    def test_invalid_dimension(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        with self.assertRaises(ValueError):
+            IntervalData(position.expand(1), [1])
+
+    def test_invalid_dimension_dis(self):
+        for name, dis in _dis_cases(2):
+            with self.subTest(name):
+                with self.assertRaises(ValueError):
+                    IntervalData(dis, [1])
+
+    def test_outside_range(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(3, 10)
+        interval_data = IntervalData(interval, data)
+        with self.assertRaises(IndexError):
+            interval_data[len(data)]
+
+    def test_outside_range_dis(self):
+        data = np.arange(0, 30).reshape(3, 10)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                with self.assertRaises(IndexError):
+                    interval_data[len(data)]
+
+    def test_set(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(3, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        interval_data[0] = interval_data[0].transpose()
+        np.testing.assert_equal(data[0].transpose(), interval_data[0])
+
+    def test_set_dis(self):
+        data = np.arange(0, 30).reshape(3, 10)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, deepcopy(data))
+                interval_data[0] = interval_data[0].transpose()
+                np.testing.assert_equal(data[0].transpose(), interval_data[0])
+
+
+class TestIntervalDataSliceIndex(unittest.TestCase):
+    rank = 3
+
+    @classmethod
+    def setUpClass(cls):
+        cls.genome = MiniGenome(REFG)
+
+    def test_slice_index(self):
+        rank = self.rank
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, rank)
+        dna = self.genome.dna(interval)
+        data = np.arange(0, 10 * rank).reshape(rank, 10)
+        interval_data = IntervalData(interval, data)
+
+        for name, kwargs in _slice_index_cases(rank):
+            with self.subTest(name):
+                start = kwargs.get('start')
+                stop = kwargs.get('stop')
+                step = kwargs.get('step')
+                if kwargs.get('throws'):
+                    with self.assertRaises(KeyError):
+                        interval_data[start:stop:step]
+                else:
+                    sliced = interval_data[start:stop:step]
+                    expected_dna = dna[start:stop:step]
+                    if step is not None and step < 0:
+                        expected_dna = expected_dna.translate(nucleotide_complement)
+                    self.assertEqual(expected_dna, self.genome.dna(sliced.interval))
+                    np.testing.assert_equal(
+                        [x for x in data[start:stop:step]], [x for x in sliced]
+                    )
+
+    def test_slice_index_dis(self):
+        rank = self.rank
+        data = np.arange(0, 10 * rank).reshape(rank, 10)
+
+        for dis_name, dis in _dis_cases(rank):
+            interval_data = IntervalData(dis, data)
+            dna = dis.dna()
+            for name, kwargs in _slice_index_cases(rank):
+                with self.subTest(f"{dis_name}:{name}"):
+                    start = kwargs.get('start')
+                    stop = kwargs.get('stop')
+                    step = kwargs.get('step')
+                    if kwargs.get('throws'):
+                        with self.assertRaises(KeyError):
+                            interval_data[start:stop:step]
+                    else:
+                        sliced = interval_data[start:stop:step]
+                        expected_dna = dna[start:stop:step]
+                        if step is not None and step < 0:
+                            expected_dna = expected_dna.translate(nucleotide_complement)
+                        self.assertEqual(expected_dna, sliced.interval.dna())
+                        np.testing.assert_equal(
+                            [x for x in data[start:stop:step]], [x for x in sliced]
+                        )
+
+    def test_negative_strand_negative_step(self):
+        rank = self.rank
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, rank).as_opposite_strand()
+        data = np.arange(0, 10 * rank).reshape(rank, 10)
+        start = None
+        stop = 1
+        step = -1  # Will flip the strand and reverse the slice
+        interval_data = IntervalData(interval, data)[start:stop:step]
+        dna = self.genome.dna(interval)[start:stop:step].translate(nucleotide_complement)
+        expected_data = data[start:stop:step]
+        self.assertEqual(dna, self.genome.dna(interval_data.interval))
+        np.testing.assert_equal([x for x in expected_data], [x for x in interval_data])
+
+    def test_negative_strand_negative_step_dis(self):
+        rank = self.rank
+        data = np.arange(0, 10 * rank).reshape(rank, 10)
+        start = None
+        stop = 1
+        step = -1  # Will flip the strand and reverse the slice
+        for name, dis in _dis_cases(rank):
+            with self.subTest(name):
+                backing = dis.as_opposite_strand()
+                interval_data = IntervalData(backing, data)[start:stop:step]
+                dna = backing.dna()[start:stop:step].translate(nucleotide_complement)
+                expected_data = data[start:stop:step]
+                self.assertEqual(dna, interval_data.interval.dna())
+                np.testing.assert_equal(
+                    [x for x in expected_data], [x for x in interval_data]
+                )
+
+    def test_negative_strand(self):
+        rank = self.rank
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, rank).as_opposite_strand()
+        data = np.arange(0, 10 * rank).reshape(rank, 10)
+        start = 2
+        stop = None
+        step = 1
+        interval_data = IntervalData(interval, data)[start:stop:step]
+        dna = self.genome.dna(interval)[start:stop:step]
+        expected_data = data[start:stop:step]
+        self.assertEqual(dna, self.genome.dna(interval_data.interval))
+        np.testing.assert_equal([x for x in expected_data], [x for x in interval_data])
+
+    def test_negative_strand_dis(self):
+        rank = self.rank
+        data = np.arange(0, 10 * rank).reshape(rank, 10)
+        start = 2
+        stop = None
+        step = 1
+        for name, dis in _dis_cases(rank):
+            with self.subTest(name):
+                backing = dis.as_opposite_strand()
+                interval_data = IntervalData(backing, data)[start:stop:step]
+                dna = backing.dna()[start:stop:step]
+                expected_data = data[start:stop:step]
+                self.assertEqual(dna, interval_data.interval.dna())
+                np.testing.assert_equal(
+                    [x for x in expected_data], [x for x in interval_data]
+                )
+
+
+class TestIntervalDataSliceInterval(unittest.TestCase):
+    rank = 3
+
+    @classmethod
+    def setUpClass(cls):
+        cls.genome = MiniGenome(REFG)
+
+    def test_empty(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, data)
+        sliced = interval_data[position]
+        self.assertEqual(position, sliced.interval)
+        self.assertEqual(0, len([x for x in sliced]))
+
+    def test_empty_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                sliced = interval_data[dis.end5]
+                self.assertEqual(dis.end5, sliced.interval)
+                self.assertEqual(0, len([x for x in sliced]))
+
+    def test_full(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, data)
+        sliced = interval_data[interval]
+        self.assertEqual(interval, sliced.interval)
+        np.testing.assert_equal(data, [x for x in sliced])
+
+    def test_full_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                sliced = interval_data[dis]
+                self.assertEqual(dis, sliced.interval)
+                np.testing.assert_equal(data, [x for x in sliced])
+
+    def test_outside_range(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, data)
+        with self.assertRaises(IndexError):
+            interval_data[interval.shift(1)]
+
+    def test_outside_range_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                with self.assertRaises(IndexError):
+                    interval_data[dis.shift(1)]
+
+    def test_start_middle(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        base = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(base, data)
+        interval = base.expand(-1, 0)
+        sliced = interval_data[interval]
+        self.assertEqual(interval, sliced.interval)
+        np.testing.assert_equal(data[1:], [x for x in sliced])
+
+    def test_start_middle_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                key = dis.expand(-1, 0)
+                sliced = interval_data[key]
+                self.assertEqual(key, sliced.interval)
+                np.testing.assert_equal(data[1:], [x for x in sliced])
+
+    def test_end_middle(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        base = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(base, data)
+        interval = base.expand(0, -1)
+        sliced = interval_data[interval]
+        self.assertEqual(interval, sliced.interval)
+        np.testing.assert_equal(data[:-1], [x for x in sliced])
+
+    def test_end_middle_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                key = dis.expand(0, -1)
+                sliced = interval_data[key]
+                self.assertEqual(key, sliced.interval)
+                np.testing.assert_equal(data[:-1], [x for x in sliced])
+
+    def test_reverse_full(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        base = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(base, data)
+        interval = base.as_opposite_strand()
+        sliced = interval_data[interval]
+        self.assertEqual(interval, sliced.interval)
+        np.testing.assert_equal(data[::-1], [x for x in sliced])
+
+    def test_reverse_full_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                key = dis.as_opposite_strand()
+                sliced = interval_data[key]
+                self.assertEqual(key, sliced.interval)
+                np.testing.assert_equal(data[::-1], [x for x in sliced])
+
+    def test_reverse_start_middle(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        base = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(base, data)
+        interval = base.as_opposite_strand().expand(-1, 0)
+        sliced = interval_data[interval]
+        self.assertEqual(interval, sliced.interval)
+        np.testing.assert_equal(data[-2::-1], [x for x in sliced])
+
+    def test_reverse_start_middle_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                key = dis.as_opposite_strand().expand(-1, 0)
+                sliced = interval_data[key]
+                self.assertEqual(key, sliced.interval)
+                np.testing.assert_equal(data[-2::-1], [x for x in sliced])
+
+    def test_reverse_end_middle(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        base = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(base, data)
+        interval = base.as_opposite_strand().expand(0, -1)
+        sliced = interval_data[interval]
+        self.assertEqual(interval, sliced.interval)
+        np.testing.assert_equal(data[:0:-1], [x for x in sliced])
+
+    def test_reverse_end_middle_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data)
+                key = dis.as_opposite_strand().expand(0, -1)
+                sliced = interval_data[key]
+                self.assertEqual(key, sliced.interval)
+                np.testing.assert_equal(data[:0:-1], [x for x in sliced])
+
+    def test_negative_strand(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank).as_opposite_strand()
+        data = range(len(interval))
+        interval_data = IntervalData(interval, data)
+        np.testing.assert_equal(interval_data[interval.end5.expand(0, 1)].data, data[:1])
+        np.testing.assert_equal(interval_data[interval].data, data)
+
+    def test_negative_strand_dis(self):
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                backing = dis.as_opposite_strand()
+                data = range(len(backing))
+                interval_data = IntervalData(backing, data)
+                np.testing.assert_equal(
+                    interval_data[backing.end5.expand(0, 1)].data, data[:1]
+                )
+                np.testing.assert_equal(interval_data[backing].data, data)
+
+    def test_set_data(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        interval_data[interval.expand(-1, 0)] = 0
+        np.testing.assert_array_equal(
+            interval_data.data[1:, :], np.zeros_like(interval_data.data[1:, :])
+        )
+        np.testing.assert_array_equal(interval_data.data[:1, :], data[:1, :])
+
+    def test_set_data_dis(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for name, dis in _dis_cases(self.rank):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, deepcopy(data))
+                interval_data[dis.expand(-1, 0)] = 0
+                np.testing.assert_array_equal(
+                    interval_data.data[1:, :],
+                    np.zeros_like(interval_data.data[1:, :]),
+                )
+                np.testing.assert_array_equal(interval_data.data[:1, :], data[:1, :])
+
+
+class TestIntervalDataAxisAlign(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.genome = MiniGenome(REFG)
+
+    def test_same_dimension(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, data, axis=1)
+        self.assertEqual(len(interval), len(interval_data))
+        self.assertEqual(interval, interval_data.interval)
+        np.testing.assert_equal(data, [x for x in interval_data])
+
+    def test_same_dimension_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data, axis=1)
+                self.assertEqual(len(dis), len(interval_data))
+                self.assertEqual(dis, interval_data.interval)
+                np.testing.assert_equal(data, [x for x in interval_data])
+
+    def test_negative_axis(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        with self.assertRaises(IndexError):
+            IntervalData(interval, data, -1)
+
+    def test_negative_axis_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                with self.assertRaises(IndexError):
+                    IntervalData(dis, data, -1)
+
+    def test_invalid_dimensions(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        with self.assertRaises(ValueError):
+            IntervalData(interval, data)
+        with self.assertRaises(ValueError):
+            IntervalData(interval, data, 2)
+
+    def test_invalid_dimensions_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                with self.assertRaises(ValueError):
+                    IntervalData(dis, data)
+                with self.assertRaises(ValueError):
+                    IntervalData(dis, data, 2)
+
+    def test_outside_range(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, data, axis=1)
+        with self.assertRaises(IndexError):
+            interval_data[0, data.shape[1], 0]
+
+    def test_outside_range_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data, axis=1)
+                with self.assertRaises(IndexError):
+                    interval_data[0, data.shape[1], 0]
+
+    def test_invalid_slice(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, data, axis=1)
+        with self.assertRaises(IndexError):
+            interval_data[1:]
+
+    def test_invalid_slice_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data, axis=1)
+                with self.assertRaises(IndexError):
+                    interval_data[1:]
+
+    def test_slice_index(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, data, axis=1)
+        start = 1
+        sliced = interval_data[:, start:, ...]
+        self.assertEqual(interval.expand(-1, 0), sliced.interval)
+        np.testing.assert_equal(data[:, start:, ...], [x for x in sliced])
+
+    def test_slice_index_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        start = 1
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data, axis=1)
+                sliced = interval_data[:, start:, ...]
+                self.assertEqual(dis.expand(-1, 0), sliced.interval)
+                np.testing.assert_equal(data[:, start:, ...], [x for x in sliced])
+
+    def test_slice_interval(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        base = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(base, data, axis=1)
+        interval = base.expand(-1, 0)
+        sliced = interval_data[interval]
+        self.assertEqual(interval, sliced.interval)
+        np.testing.assert_equal(data[:, 1:, ...], [x for x in sliced])
+
+    def test_slice_interval_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data, axis=1)
+                key = dis.expand(-1, 0)
+                sliced = interval_data[key]
+                self.assertEqual(key, sliced.interval)
+                np.testing.assert_equal(data[:, 1:, ...], [x for x in sliced])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_interval_data.py
+++ b/tests/test_interval_data.py
@@ -566,6 +566,22 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
                 with self.assertRaises(IndexError):
                     interval_data[1:]
 
+    def test_invalid_slice_set(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, data, axis=1)
+        with self.assertRaises(IndexError):
+            interval_data[1:] = 0
+
+    def test_invalid_slice_set_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, data, axis=1)
+                with self.assertRaises(IndexError):
+                    interval_data[1:] = 0
+
     def test_slice_index(self):
         position = Interval('chr1', '+', 100, 100, self.genome)
         interval = position.expand(0, 3)
@@ -605,6 +621,29 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
                 sliced = interval_data[key]
                 self.assertEqual(key, sliced.interval)
                 np.testing.assert_equal(data[:, 1:, ...], [x for x in sliced])
+
+    def test_set_data(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, deepcopy(data), axis=1)
+        interval_data[interval.expand(-1, 0)] = 0
+        np.testing.assert_array_equal(
+            interval_data.data[:, 1:, :], np.zeros_like(interval_data.data[:, 1:, :])
+        )
+        np.testing.assert_array_equal(interval_data.data[:, :1, :], data[:, :1, :])
+
+    def test_set_data_dis(self):
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        for name, dis in _dis_cases(3):
+            with self.subTest(name):
+                interval_data = IntervalData(dis, deepcopy(data), axis=1)
+                interval_data[dis.expand(-1, 0)] = 0
+                np.testing.assert_array_equal(
+                    interval_data.data[:, 1:, :],
+                    np.zeros_like(interval_data.data[:, 1:, :]),
+                )
+                np.testing.assert_array_equal(interval_data.data[:, :1, :], data[:, :1, :])
 
 
 if __name__ == '__main__':

--- a/tests/test_interval_data.py
+++ b/tests/test_interval_data.py
@@ -620,6 +620,254 @@ class TestIntervalDataSliceInterval(unittest.TestCase):
         untouched_mask[100:105] = False
         np.testing.assert_array_equal(interval_data._data[untouched_mask], data[untouched_mask])
 
+    def test_set_list_key_on_interval_backed(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        key = [
+            Interval('chr1', '+', 101, 102, self.genome),
+            Interval('chr1', '+', 102, 103, self.genome),
+        ]
+        interval_data[key] = 0
+        np.testing.assert_array_equal(
+            interval_data._data[1:, :], np.zeros_like(interval_data._data[1:, :])
+        )
+        np.testing.assert_array_equal(interval_data._data[:1, :], data[:1, :])
+
+    def test_set_list_key_on_dis_backed(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        single = _make_intervals([("chr1", "+", 100, 200)])
+        dis = DisjointIntervalSequence(single, start=50, end=50 + self.rank)
+        interval_data = IntervalData(dis, deepcopy(data))
+        key = [
+            Interval("chr1", "+", 151, 152, self.genome),
+            Interval("chr1", "+", 152, 153, self.genome),
+        ]
+        interval_data[key] = 0
+        np.testing.assert_array_equal(
+            interval_data._data[1:, :], np.zeros_like(interval_data._data[1:, :])
+        )
+        np.testing.assert_array_equal(interval_data._data[:1, :], data[:1, :])
+
+    def test_set_list_key_multi_region(self):
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        interval_data[[e1, e2]] = 0
+
+        zeroed_mask = np.zeros(len(backing), dtype=bool)
+        zeroed_mask[0:5] = True
+        zeroed_mask[100:105] = True
+        np.testing.assert_array_equal(
+            interval_data._data[zeroed_mask], np.zeros_like(interval_data._data[zeroed_mask])
+        )
+        np.testing.assert_array_equal(interval_data._data[~zeroed_mask], data[~zeroed_mask])
+
+    def test_set_list_key_multi_region_array_value(self):
+        # value's length matches the combined length of the list's elements,
+        # so it should be split per element rather than broadcast whole into
+        # each one.
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        value = -np.arange(1, 10 * 10 + 1).reshape(10, 10)
+        interval_data[[e1, e2]] = value
+
+        np.testing.assert_array_equal(interval_data._data[0:5, :], value[0:5, :])
+        np.testing.assert_array_equal(interval_data._data[100:105, :], value[5:10, :])
+        untouched_mask = np.ones(len(backing), dtype=bool)
+        untouched_mask[0:5] = False
+        untouched_mask[100:105] = False
+        np.testing.assert_array_equal(interval_data._data[untouched_mask], data[untouched_mask])
+
+    def test_set_list_key_invalid_value_shape(self):
+        # value's length along the aligned axis (7) doesn't match the
+        # combined length of the list's elements (10), so the up-front shape
+        # check should raise before any assignment.
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        value = np.zeros((7, 10))
+        with self.assertRaises(ValueError):
+            interval_data[[e1, e2]] = value
+        np.testing.assert_array_equal(interval_data._data, data)
+
+    def test_set_data_invalid_value_shape(self):
+        # value's length along the aligned axis (7) doesn't match the
+        # length of the Interval key (2), so the up-front shape check
+        # should raise before any assignment.
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        value = np.zeros((7, 10))
+        with self.assertRaises(ValueError):
+            interval_data[interval.expand(-1, 0)] = value
+        np.testing.assert_array_equal(interval_data._data, data)
+
+    def test_set_data_position_value(self):
+        # value has data's shape with the aligned axis removed, so it describes a
+        # single position and is broadcast to every position the key selects.
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        value = -np.arange(1, 11)
+        interval_data[interval.expand(-1, 0)] = value
+
+        np.testing.assert_array_equal(
+            interval_data._data[1:, :], np.broadcast_to(value, (self.rank - 1, 10))
+        )
+        np.testing.assert_array_equal(interval_data._data[:1, :], data[:1, :])
+
+    def test_set_list_key_multi_region_position_value(self):
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        value = -np.arange(1, 11)
+        interval_data[[e1, e2]] = value
+
+        selected_mask = np.zeros(len(backing), dtype=bool)
+        selected_mask[0:5] = True
+        selected_mask[100:105] = True
+        np.testing.assert_array_equal(
+            interval_data._data[selected_mask], np.broadcast_to(value, (10, 10))
+        )
+        np.testing.assert_array_equal(interval_data._data[~selected_mask], data[~selected_mask])
+
+    def test_set_data_dis_key_on_interval_backed_position_value(self):
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        value = -np.arange(1, 11)
+        interval_data[DisjointIntervalSequence([e1, e2], start=0, end=10)] = value
+
+        selected_mask = np.zeros(len(backing), dtype=bool)
+        selected_mask[0:5] = True
+        selected_mask[100:105] = True
+        np.testing.assert_array_equal(
+            interval_data._data[selected_mask], np.broadcast_to(value, (10, 10))
+        )
+        np.testing.assert_array_equal(interval_data._data[~selected_mask], data[~selected_mask])
+
+    def test_set_data_broadcastable_value_rejected(self):
+        # (rank, 1) and (1, 10) would each reach the aligned axis only through
+        # NumPy's right-aligned broadcasting, so neither is accepted even though
+        # NumPy would stretch them to fit.
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        for shape in [(self.rank, 1), (1, 10)]:
+            with self.subTest(shape):
+                interval_data = IntervalData(interval, deepcopy(data))
+                with self.assertRaises(ValueError):
+                    interval_data[interval] = np.zeros(shape)
+                np.testing.assert_array_equal(interval_data._data, data)
+
+    def test_set_list_key_unordered_splits_5p_to_3p(self):
+        # __getitem__ concatenates a list key in 5'->3' order, so __setitem__ must
+        # split a block-shaped value in that order too, whatever order was given.
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        value = -np.arange(1, 10 * 10 + 1).reshape(10, 10)
+        interval_data[[e2, e1]] = value
+
+        np.testing.assert_array_equal(interval_data._data[0:5, :], value[0:5, :])
+        np.testing.assert_array_equal(interval_data._data[100:105, :], value[5:10, :])
+        np.testing.assert_array_equal(interval_data[e1].data, value[0:5, :])
+        np.testing.assert_array_equal(interval_data[e2].data, value[5:10, :])
+
+    def test_set_list_key_unordered_splits_5p_to_3p_minus_strand(self):
+        # on the minus strand 5'->3' runs from high coordinates to low, so e2 is the
+        # 5'-most region
+        e1 = Interval('chr1', '-', 100, 105, self.genome)
+        e2 = Interval('chr1', '-', 200, 205, self.genome)
+        backing = Interval('chr1', '-', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        value = -np.arange(1, 10 * 10 + 1).reshape(10, 10)
+        interval_data[[e1, e2]] = value
+
+        # index 0 is the 5' end, i.e. genomic 205, so e2 takes the first chunk
+        np.testing.assert_array_equal(interval_data._data[0:5, :], value[0:5, :])
+        np.testing.assert_array_equal(interval_data._data[100:105, :], value[5:10, :])
+        np.testing.assert_array_equal(interval_data[e2].data, value[0:5, :])
+        np.testing.assert_array_equal(interval_data[e1].data, value[5:10, :])
+
+    def test_set_list_key_round_trip(self):
+        # a block-shaped value is exactly what __getitem__ returns for the same
+        # key, so writing it straight back must leave data untouched.
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        for name, key in [("ordered", [e1, e2]), ("unordered", [e2, e1])]:
+            with self.subTest(name):
+                interval_data = IntervalData(backing, deepcopy(data))
+                interval_data[key] = interval_data[key].data
+                np.testing.assert_array_equal(interval_data._data, data)
+
+    def test_set_list_key_empty(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        with self.assertRaises(ValueError):
+            interval_data[[]] = 0
+        np.testing.assert_array_equal(interval_data._data, data)
+
+    def test_set_list_key_invalid_element(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        key = [Interval('chr1', '+', 101, 102, self.genome), slice(0, 1)]
+        with self.assertRaises(TypeError):
+            interval_data[key] = 0
+        np.testing.assert_array_equal(interval_data._data, data)
+
+    def test_set_list_key_overlapping(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        key = [
+            Interval('chr1', '+', 100, 102, self.genome),
+            Interval('chr1', '+', 101, 103, self.genome),
+        ]
+        with self.assertRaises(ValueError):
+            interval_data[key] = 0
+        np.testing.assert_array_equal(interval_data._data, data)
+
+    def test_set_list_key_overlapping_unordered(self):
+        # a and c overlap; b sits elsewhere and overlaps neither. Passed in
+        # list order [a, b, c] to verify the overlap is still caught after
+        # sorting 5'->3', even though a and c are not adjacent in the given
+        # (unsorted) list order.
+        backing = Interval('chr1', '+', 100, 215, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        a = Interval('chr1', '+', 100, 110, self.genome)
+        b = Interval('chr1', '+', 200, 210, self.genome)
+        c = Interval('chr1', '+', 105, 115, self.genome)
+        with self.assertRaises(ValueError):
+            interval_data[[a, b, c]] = 0
+        np.testing.assert_array_equal(interval_data._data, data)
+
 
 class TestIntervalDataAxisAlign(unittest.TestCase):
     @classmethod
@@ -841,6 +1089,41 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
         np.testing.assert_array_equal(interval_data._data[:, 1, :], value[:, 0, :])
         np.testing.assert_array_equal(interval_data._data[:, 2, :], value[:, 1, :])
         np.testing.assert_array_equal(interval_data._data[:, :1, :], data[:, :1, :])
+
+    def test_set_position_value(self):
+        # data's shape with the aligned axis (1) removed is (5, 2); that value is
+        # broadcast along the aligned axis, not right-aligned onto the trailing one.
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        value = -np.arange(1, 5 * 2 + 1).reshape(5, 2)
+        key = [
+            Interval('chr1', '+', 101, 102, self.genome),
+            Interval('chr1', '+', 102, 103, self.genome),
+        ]
+        for name, item in [("interval", interval.expand(-1, 0)), ("list", key)]:
+            with self.subTest(name):
+                interval_data = IntervalData(interval, deepcopy(data), axis=1)
+                interval_data[item] = value
+                np.testing.assert_array_equal(interval_data._data[:, 1, :], value)
+                np.testing.assert_array_equal(interval_data._data[:, 2, :], value)
+                np.testing.assert_array_equal(interval_data._data[:, :1, :], data[:, :1, :])
+
+    def test_set_ambiguous_value_rejected(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        key = [
+            Interval('chr1', '+', 101, 102, self.genome),
+            Interval('chr1', '+', 102, 103, self.genome),
+        ]
+        # Shapes where assignment is ambigous should be rejected
+        for shape in [(2,), (1, 1, 2), (2, 2), (5, 2, 1)]:
+            with self.subTest(shape):
+                interval_data = IntervalData(interval, deepcopy(data), axis=1)
+                with self.assertRaises(ValueError):
+                    interval_data[key] = np.zeros(shape)
+                np.testing.assert_array_equal(interval_data._data, data)
 
     def test_set_data_dis(self):
         data = np.arange(0, 30).reshape(5, 3, 2)

--- a/tests/test_interval_data.py
+++ b/tests/test_interval_data.py
@@ -87,7 +87,7 @@ class TestIntervalData(unittest.TestCase):
         data = np.arange(0, 30).reshape(3, 10)
         interval_data = IntervalData(interval, data)
         self.assertEqual(len(interval), len(interval_data))
-        self.assertEqual(interval, interval_data.interval)
+        self.assertEqual(interval, interval_data._interval)
         np.testing.assert_equal(data, [x for x in interval_data])
 
     def test_same_dimension_dis(self):
@@ -96,7 +96,7 @@ class TestIntervalData(unittest.TestCase):
             with self.subTest(name):
                 interval_data = IntervalData(dis, data)
                 self.assertEqual(len(dis), len(interval_data))
-                self.assertEqual(dis, interval_data.interval)
+                self.assertEqual(dis, interval_data._interval)
                 np.testing.assert_equal(data, [x for x in interval_data])
 
     def test_empty(self):
@@ -462,9 +462,9 @@ class TestIntervalDataSliceInterval(unittest.TestCase):
         interval_data = IntervalData(interval, deepcopy(data))
         interval_data[interval.expand(-1, 0)] = 0
         np.testing.assert_array_equal(
-            interval_data.data[1:, :], np.zeros_like(interval_data.data[1:, :])
+            interval_data._data[1:, :], np.zeros_like(interval_data._data[1:, :])
         )
-        np.testing.assert_array_equal(interval_data.data[:1, :], data[:1, :])
+        np.testing.assert_array_equal(interval_data._data[:1, :], data[:1, :])
 
     def test_set_data_dis(self):
         data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
@@ -473,10 +473,10 @@ class TestIntervalDataSliceInterval(unittest.TestCase):
                 interval_data = IntervalData(dis, deepcopy(data))
                 interval_data[dis.expand(-1, 0)] = 0
                 np.testing.assert_array_equal(
-                    interval_data.data[1:, :],
-                    np.zeros_like(interval_data.data[1:, :]),
+                    interval_data._data[1:, :],
+                    np.zeros_like(interval_data._data[1:, :]),
                 )
-                np.testing.assert_array_equal(interval_data.data[:1, :], data[:1, :])
+                np.testing.assert_array_equal(interval_data._data[:1, :], data[:1, :])
 
 
 class TestIntervalDataAxisAlign(unittest.TestCase):
@@ -490,7 +490,7 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
         data = np.arange(0, 30).reshape(5, 3, 2)
         interval_data = IntervalData(interval, data, axis=1)
         self.assertEqual(len(interval), len(interval_data))
-        self.assertEqual(interval, interval_data.interval)
+        self.assertEqual(interval, interval_data._interval)
         np.testing.assert_equal(data, [x for x in interval_data])
 
     def test_same_dimension_dis(self):
@@ -499,7 +499,7 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
             with self.subTest(name):
                 interval_data = IntervalData(dis, data, axis=1)
                 self.assertEqual(len(dis), len(interval_data))
-                self.assertEqual(dis, interval_data.interval)
+                self.assertEqual(dis, interval_data._interval)
                 np.testing.assert_equal(data, [x for x in interval_data])
 
     def test_negative_axis(self):
@@ -629,9 +629,9 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
         interval_data = IntervalData(interval, deepcopy(data), axis=1)
         interval_data[interval.expand(-1, 0)] = 0
         np.testing.assert_array_equal(
-            interval_data.data[:, 1:, :], np.zeros_like(interval_data.data[:, 1:, :])
+            interval_data._data[:, 1:, :], np.zeros_like(interval_data._data[:, 1:, :])
         )
-        np.testing.assert_array_equal(interval_data.data[:, :1, :], data[:, :1, :])
+        np.testing.assert_array_equal(interval_data._data[:, :1, :], data[:, :1, :])
 
     def test_set_data_dis(self):
         data = np.arange(0, 30).reshape(5, 3, 2)
@@ -640,10 +640,10 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
                 interval_data = IntervalData(dis, deepcopy(data), axis=1)
                 interval_data[dis.expand(-1, 0)] = 0
                 np.testing.assert_array_equal(
-                    interval_data.data[:, 1:, :],
-                    np.zeros_like(interval_data.data[:, 1:, :]),
+                    interval_data._data[:, 1:, :],
+                    np.zeros_like(interval_data._data[:, 1:, :]),
                 )
-                np.testing.assert_array_equal(interval_data.data[:, :1, :], data[:, :1, :])
+                np.testing.assert_array_equal(interval_data._data[:, :1, :], data[:, :1, :])
 
 
 if __name__ == '__main__':

--- a/tests/test_interval_data.py
+++ b/tests/test_interval_data.py
@@ -320,6 +320,99 @@ class TestIntervalDataSliceInterval(unittest.TestCase):
                 self.assertEqual(dis, sliced.interval)
                 np.testing.assert_equal(data, [x for x in sliced])
 
+    def test_dis_key_on_interval_backed(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, data)
+        key = DisjointIntervalSequence([interval], start=1, end=self.rank)
+        sliced = interval_data[key]
+        self.assertEqual(key, sliced.interval)
+        np.testing.assert_equal(data[1:, :], sliced.data)
+
+    def test_dis_key_on_interval_backed_multi_region(self):
+        # DIS spans two coord intervals with a gap between them; lowering it
+        # against Interval-backed data must fetch (and concatenate) each
+        # genomic sub-interval's data separately, skipping the gap.
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, data)
+        key = DisjointIntervalSequence([e1, e2], start=0, end=10)
+        sliced = interval_data[key]
+        self.assertEqual(key, sliced.interval)
+        np.testing.assert_equal(
+            np.concatenate([data[0:5, :], data[100:105, :]]), sliced.data
+        )
+
+    def test_list_key_on_interval_backed(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, data)
+        key = [
+            Interval('chr1', '+', 101, 102, self.genome),
+            Interval('chr1', '+', 102, 103, self.genome),
+        ]
+        sliced = interval_data[key]
+        np.testing.assert_equal(data[1:, :], sliced.data)
+
+    def test_list_key_on_dis_backed(self):
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        single = _make_intervals([("chr1", "+", 100, 200)])
+        dis = DisjointIntervalSequence(single, start=50, end=50 + self.rank)
+        interval_data = IntervalData(dis, data)
+        key = [
+            Interval("chr1", "+", 151, 152, self.genome),
+            Interval("chr1", "+", 152, 153, self.genome),
+        ]
+        sliced = interval_data[key]
+        np.testing.assert_equal(data[1:, :], sliced.data)
+
+    def test_list_key_multi_region(self):
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, data)
+        sliced = interval_data[[e1, e2]]
+        np.testing.assert_equal(
+            np.concatenate([data[0:5, :], data[100:105, :]]), sliced.data
+        )
+
+    def test_list_key_invalid_element(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, data)
+        key = [Interval('chr1', '+', 101, 102, self.genome), slice(0, 1)]
+        with self.assertRaises(TypeError):
+            interval_data[key]
+
+    def test_list_key_overlapping(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, data)
+        key = [
+            Interval('chr1', '+', 100, 102, self.genome),
+            Interval('chr1', '+', 101, 103, self.genome),
+        ]
+        with self.assertRaises(ValueError):
+            interval_data[key]
+
+    def test_list_key_overlapping_unordered(self):
+        # a and c overlap; b sits elsewhere and overlaps neither
+        backing = Interval('chr1', '+', 100, 215, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, data)
+        a = Interval('chr1', '+', 100, 110, self.genome)
+        b = Interval('chr1', '+', 200, 210, self.genome)
+        c = Interval('chr1', '+', 105, 115, self.genome)
+        with self.assertRaises(ValueError):
+            interval_data[[a, b, c]]
+
     def test_outside_range(self):
         position = Interval('chr1', '+', 100, 100, self.genome)
         interval = position.expand(0, self.rank)
@@ -466,6 +559,18 @@ class TestIntervalDataSliceInterval(unittest.TestCase):
         )
         np.testing.assert_array_equal(interval_data._data[:1, :], data[:1, :])
 
+    def test_set_data_dis_key_on_interval_backed(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, self.rank)
+        data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
+        interval_data = IntervalData(interval, deepcopy(data))
+        key = DisjointIntervalSequence([interval], start=1, end=self.rank)
+        interval_data[key] = 0
+        np.testing.assert_array_equal(
+            interval_data._data[1:, :], np.zeros_like(interval_data._data[1:, :])
+        )
+        np.testing.assert_array_equal(interval_data._data[:1, :], data[:1, :])
+
     def test_set_data_dis(self):
         data = np.arange(0, 10 * self.rank).reshape(self.rank, 10)
         for name, dis in _dis_cases(self.rank):
@@ -477,6 +582,43 @@ class TestIntervalDataSliceInterval(unittest.TestCase):
                     np.zeros_like(interval_data._data[1:, :]),
                 )
                 np.testing.assert_array_equal(interval_data._data[:1, :], data[:1, :])
+
+    def test_set_data_dis_key_on_interval_backed_multi_region(self):
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        key = DisjointIntervalSequence([e1, e2], start=0, end=10)
+        interval_data[key] = 0
+
+        zeroed_mask = np.zeros(len(backing), dtype=bool)
+        zeroed_mask[0:5] = True
+        zeroed_mask[100:105] = True
+        np.testing.assert_array_equal(
+            interval_data._data[zeroed_mask], np.zeros_like(interval_data._data[zeroed_mask])
+        )
+        np.testing.assert_array_equal(interval_data._data[~zeroed_mask], data[~zeroed_mask])
+
+    def test_set_data_dis_key_on_interval_backed_multi_region_array_value(self):
+        # value's length matches the combined length of the DIS's lowered
+        # sub-intervals, so it should be split per sub-interval rather than
+        # broadcast whole into each one.
+        e1 = Interval('chr1', '+', 100, 105, self.genome)
+        e2 = Interval('chr1', '+', 200, 205, self.genome)
+        backing = Interval('chr1', '+', 100, 205, self.genome)
+        data = np.arange(0, 10 * len(backing)).reshape(len(backing), 10)
+        interval_data = IntervalData(backing, deepcopy(data))
+        key = DisjointIntervalSequence([e1, e2], start=0, end=10)
+        value = -np.arange(1, 10 * 10 + 1).reshape(10, 10)
+        interval_data[key] = value
+
+        np.testing.assert_array_equal(interval_data._data[0:5, :], value[0:5, :])
+        np.testing.assert_array_equal(interval_data._data[100:105, :], value[5:10, :])
+        untouched_mask = np.ones(len(backing), dtype=bool)
+        untouched_mask[0:5] = False
+        untouched_mask[100:105] = False
+        np.testing.assert_array_equal(interval_data._data[untouched_mask], data[untouched_mask])
 
 
 class TestIntervalDataAxisAlign(unittest.TestCase):
@@ -622,6 +764,28 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
                 self.assertEqual(key, sliced.interval)
                 np.testing.assert_equal(data[:, 1:, ...], [x for x in sliced])
 
+    def test_dis_key_on_interval_backed(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, data, axis=1)
+        key = DisjointIntervalSequence([interval], start=1, end=3)
+        sliced = interval_data[key]
+        self.assertEqual(key, sliced.interval)
+        np.testing.assert_equal(data[:, 1:, ...], sliced.data)
+
+    def test_list_key_on_interval_backed(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, data, axis=1)
+        key = [
+            Interval('chr1', '+', 101, 102, self.genome),
+            Interval('chr1', '+', 102, 103, self.genome),
+        ]
+        sliced = interval_data[key]
+        np.testing.assert_equal(data[:, 1:, ...], sliced.data)
+
     def test_set_data(self):
         position = Interval('chr1', '+', 100, 100, self.genome)
         interval = position.expand(0, 3)
@@ -631,6 +795,51 @@ class TestIntervalDataAxisAlign(unittest.TestCase):
         np.testing.assert_array_equal(
             interval_data._data[:, 1:, :], np.zeros_like(interval_data._data[:, 1:, :])
         )
+        np.testing.assert_array_equal(interval_data._data[:, :1, :], data[:, :1, :])
+
+    def test_set_data_dis_key_on_interval_backed(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, deepcopy(data), axis=1)
+        key = DisjointIntervalSequence([interval], start=1, end=3)
+        interval_data[key] = 0
+        np.testing.assert_array_equal(
+            interval_data._data[:, 1:, :], np.zeros_like(interval_data._data[:, 1:, :])
+        )
+        np.testing.assert_array_equal(interval_data._data[:, :1, :], data[:, :1, :])
+
+    def test_set_list_key_on_interval_backed(self):
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, deepcopy(data), axis=1)
+        key = [
+            Interval('chr1', '+', 101, 102, self.genome),
+            Interval('chr1', '+', 102, 103, self.genome),
+        ]
+        interval_data[key] = 0
+        np.testing.assert_array_equal(
+            interval_data._data[:, 1:, :], np.zeros_like(interval_data._data[:, 1:, :])
+        )
+        np.testing.assert_array_equal(interval_data._data[:, :1, :], data[:, :1, :])
+
+    def test_set_list_key_on_interval_backed_array_value(self):
+        # value's length along the aligned axis matches the combined length
+        # of the list's elements, so it should be split per element rather
+        # than broadcast whole into each one.
+        position = Interval('chr1', '+', 100, 100, self.genome)
+        interval = position.expand(0, 3)
+        data = np.arange(0, 30).reshape(5, 3, 2)
+        interval_data = IntervalData(interval, deepcopy(data), axis=1)
+        key = [
+            Interval('chr1', '+', 101, 102, self.genome),
+            Interval('chr1', '+', 102, 103, self.genome),
+        ]
+        value = -np.arange(1, 5 * 2 * 2 + 1).reshape(5, 2, 2)
+        interval_data[key] = value
+        np.testing.assert_array_equal(interval_data._data[:, 1, :], value[:, 0, :])
+        np.testing.assert_array_equal(interval_data._data[:, 2, :], value[:, 1, :])
         np.testing.assert_array_equal(interval_data._data[:, :1, :], data[:, :1, :])
 
     def test_set_data_dis(self):


### PR DESCRIPTION
DIS api compatibility with Interval, required for IntervalData:
* chore: add .contains() to DIS api
* chore: support 0-length liftover with DIS
* chore: rename DIS flip_strand() to as_opposite_strand()
* fix: InvalidConfig error when using DefaultDataManager without auth

also:
* feat: update DIS lift_interval() to raise error in some instances
* feat: add cut() to DIS api
